### PR TITLE
Fix Spanish typo in legal page

### DIFF
--- a/src/legal/_copyright.php
+++ b/src/legal/_copyright.php
@@ -89,7 +89,7 @@
             </ul>
             <ul class="mtl ptl">
                 <li><a href="https://creativecommons.org/licenses/by-nc-nd/4.0/deed.es#" class="nota black">Ver Resumen</a></li>
-                <li><a href="https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode" class="nota black">Ver Liencia</a></li>
+                <li><a href="https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode" class="nota black">Ver Licencia</a></li>
             </ul>
         </section>
         


### PR DESCRIPTION
## Summary
- fix mispelled "Liencia" to "Licencia" in the legal license link

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686e8db827348327a491ac8f4cc77d7a