### PR TITLE
Add exit codes to gettext test script

### DIFF
--- a/etc/resources/gettext/gettext_test.php
+++ b/etc/resources/gettext/gettext_test.php
@@ -3,7 +3,9 @@
 
     if (!function_exists("gettext")) {
         echo 'gettext is not installed';
+        exit(1);
     } else {
         echo 'gettext is supported';
+        exit(0);
     }
 ?>


### PR DESCRIPTION
## Summary
- detect gettext support via exit codes in `gettext_test.php`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e9576a3f48327bde7e9f0b701105d