### PR TITLE
Add Sass module imports and update map helpers for Dart Sass

### DIFF
--- a/etc/css/custom/__fontFace_zh.scss
+++ b/etc/css/custom/__fontFace_zh.scss
@@ -2,6 +2,8 @@
    Font-face | Custom [/etc/css/custom/fontFace_zh.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de reglas-at, @font-face para fuentes con alfabeto chino.
 

--- a/etc/css/custom/__styles_zh.scss
+++ b/etc/css/custom/__styles_zh.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    CSS Styles Main | Custom [/etc/css/custom/styles_zh.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @import "../scss/charset";
 @import "var/env_var";
 

--- a/etc/css/custom/_animation.scss
+++ b/etc/css/custom/_animation.scss
@@ -2,6 +2,8 @@
    Animations | Custom [/etc/css/custom/animation.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_body.scss
+++ b/etc/css/custom/_body.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Body Styles | Custom [/etc/css/custom/body.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 body{
     position: relative;
     z-index: $zIndex_body;

--- a/etc/css/custom/_breadcrumbs.scss
+++ b/etc/css/custom/_breadcrumbs.scss
@@ -2,6 +2,8 @@
    Breadcrumb Styles | Custom [/etc/css/custom/breadcrumbs.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_buttons.scss
+++ b/etc/css/custom/_buttons.scss
@@ -2,6 +2,8 @@
    Button Styles | Custom [/etc/css/custom/buttons.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_classes_backgrounds.scss
+++ b/etc/css/custom/_classes_backgrounds.scss
@@ -2,6 +2,8 @@
    Backgrounds Classes | Custom [/etc/css/custom/classes_backgrounds.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_classes_text.scss
+++ b/etc/css/custom/_classes_text.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Text Classes | Custom [/etc/css/custom/classes_text.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .txBold{    
     &,
     a,

--- a/etc/css/custom/_colours_gradients.scss
+++ b/etc/css/custom/_colours_gradients.scss
@@ -2,6 +2,8 @@
    Gradient Colours | Custom [/etc/css/custom/colours_gradients.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 // Colour colourPercent 00%
 /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0.8+0,0.8+100 */
 /*

--- a/etc/css/custom/_focus.scss
+++ b/etc/css/custom/_focus.scss
@@ -2,6 +2,8 @@
    Focus Styles | Custom [/etc/css/custom/focus.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 //

--- a/etc/css/custom/_fontFace.scss
+++ b/etc/css/custom/_fontFace.scss
@@ -2,6 +2,8 @@
    Font-face | Custom [/etc/css/custom/fontFace.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de reglas-at, @font-face para fuentes
 

--- a/etc/css/custom/_footer.scss
+++ b/etc/css/custom/_footer.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Footer Styles | Custom [/etc/css/custom/footer.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @import 'imp/footer_fullHeight_imp';
 
 #footer{

--- a/etc/css/custom/_form.scss
+++ b/etc/css/custom/_form.scss
@@ -2,6 +2,8 @@
    Form Styles | Custom [/etc/css/custom/form.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Form Fieldset --------------------------------------------------------- */
 fieldset{
     &, &::before, &::after{

--- a/etc/css/custom/_form_checkbox.scss
+++ b/etc/css/custom/_form_checkbox.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Form Checkbox Accesible Styles | Custom [/etc/css/custom/form_checkbox.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @supports(-webkit-appearance: none) {
 /* 	AKA, only do this if `-webkit-appearance: none` is supported. 
         Which means IE11 and Opera Mini will get the old browser-styled checkbox. 

--- a/etc/css/custom/_form_search.scss
+++ b/etc/css/custom/_form_search.scss
@@ -2,6 +2,8 @@
    Search Form Styles | Custom [/etc/css/custom/form_search.scss]
    ========================================================================== */
 //form.searchForm
+@use "sass:color";
+@use "sass:map";
 .searchForm{
     position: relative;
     

--- a/etc/css/custom/_global.scss
+++ b/etc/css/custom/_global.scss
@@ -2,6 +2,8 @@
    Global Styles | Custom [/etc/css/custom/global.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 
@@ -117,9 +119,9 @@ $statuses_map: (
 
 @each $name, $props in $statuses_map {
     .status_#{$name} {
-        background-color: map-get($props, background);
-        color: map-get($props, color);
-        border-color: map-get($props, border);
+        background-color: map.get($props, background);
+        color: map.get($props, color);
+        border-color: map.get($props, border);
     }
 }
 

--- a/etc/css/custom/_header.scss
+++ b/etc/css/custom/_header.scss
@@ -2,6 +2,8 @@
    Header Styles | Custom [/etc/css/custom/header.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 // REF [15] Nav Fixed AT
 
 @import 'imp/header_fullHeight_imp';

--- a/etc/css/custom/_hover.scss
+++ b/etc/css/custom/_hover.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Hover Classes | Custom [/etc/css/custom/hover.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @include afterMQ768{
     // REF [19]
     .hover_grow_S_ani,

--- a/etc/css/custom/_iframe.scss
+++ b/etc/css/custom/_iframe.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    iframe Styles | Custom [/etc/css/custom/iframe.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .iframe_video_mask,
 .iframe_map_mask{
     @include borderStyle($bdGreyL);

--- a/etc/css/custom/_includes_backgrounds.scss
+++ b/etc/css/custom/_includes_backgrounds.scss
@@ -1,5 +1,7 @@
 /* * NombreDeProyecto * ========================================================
    Backgrounds Includes | Custom [/etc/css/custom/includes_backgrounds.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @include backgroundColourClassesGenerator;
 @include backgroundColourHoverClassesGenerator;

--- a/etc/css/custom/_lightbox.scss
+++ b/etc/css/custom/_lightbox.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Lightbox Styles | Custom [/etc/css/custom/lightbox.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .lightboxOverlay{
     background-color: $black_rgba_80; // #444
 }

--- a/etc/css/custom/_lists.scss
+++ b/etc/css/custom/_lists.scss
@@ -2,6 +2,8 @@
    Lists | Custom [/etc/css/custom/lists.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_mediaQueries_mx.scss
+++ b/etc/css/custom/_mediaQueries_mx.scss
@@ -2,6 +2,8 @@
    Media Queries Mixins | Custom [/etc/css/custom/mediaQueries_mx.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Este archivo contiene los mixins para generar reglas-at `@media` que
 // incluyen dentro bloques de contenido con la regla-at `@content`.

--- a/etc/css/custom/_mediaQueries_placeholders.scss
+++ b/etc/css/custom/_mediaQueries_placeholders.scss
@@ -2,6 +2,8 @@
    Media Queries Placeholders | Custom [/etc/css/custom/mediaQueries_placeholders.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
     @include beforeMQ300{}
 
     @include afterMQ300{}

--- a/etc/css/custom/_nav_lang.scss
+++ b/etc/css/custom/_nav_lang.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Language Switch Styles | Custom [/etc/css/custom/nav_lang.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .nav_lang_ul{
     z-index: $zIndex_nav_lang_ul;
     

--- a/etc/css/custom/_nav_lang_square.scss
+++ b/etc/css/custom/_nav_lang_square.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Language Switch Styles | Custom [/etc/css/custom/nav_lang.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .nav_lang_ul{
     z-index: $zIndex_nav_lang_ul;
     

--- a/etc/css/custom/_nav_main_ALL.scss
+++ b/etc/css/custom/_nav_main_ALL.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main ALL Styles | Custom [/etc/css/custom/nav_main_ALL.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .nav_main_ul{
     li{
         a,

--- a/etc/css/custom/_nav_main_AT.scss
+++ b/etc/css/custom/_nav_main_AT.scss
@@ -2,6 +2,8 @@
    Nav Main After Tablet Styles | Custom [/etc/css/custom/nav_main_AT.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 // REF [05] Container para doble nav
 // REF [15] Nav Fixed AT
 

--- a/etc/css/custom/_nav_main_accordion.scss
+++ b/etc/css/custom/_nav_main_accordion.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main Accordion Styles | Custom [/etc/css/custom/nav_main_accordion.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @if $nav_accordion_act == "on"{
     @include navBT{ // REF [03] `[/etc/css/custom/var/mediaQueries_var.scss]`
         .nav_main{

--- a/etc/css/custom/_nav_main_drawer.scss
+++ b/etc/css/custom/_nav_main_drawer.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main Drawer BT Styles | Custom [/etc/css/custom/nav_main_drawer.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @if $nav_drawer_act == "on"{
     @include beforeMQ350{
         .nav_main{

--- a/etc/css/custom/_nav_main_list.scss
+++ b/etc/css/custom/_nav_main_list.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main List Styles | Custom [/etc/css/custom/nav_main_list.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @if $nav_list_act == "on"{
     @include navBT{ // REF [03] `[/etc/css/custom/var/mediaQueries_var.scss]`
         .nav_main{

--- a/etc/css/custom/_page_construccion.scss
+++ b/etc/css/custom/_page_construccion.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Page Construccion Styles | Custom [/etc/css/custom/page_construccion.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .page_construccion{
     min-height: 400px;
     padding-bottom: 50px;

--- a/etc/css/custom/_page_contacto.scss
+++ b/etc/css/custom/_page_contacto.scss
@@ -1,4 +1,6 @@
 /* * NombreDeProyecto * ========================================================
    Page Contacto Styles | Custom [/etc/css/custom/page_contacto.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .page_contacto{}

--- a/etc/css/custom/_page_copyright.scss
+++ b/etc/css/custom/_page_copyright.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Page Copyright Styles | Custom [/etc/css/custom/page_copyright.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .page_copyright{
     padding-bottom: 100px;
     

--- a/etc/css/custom/_page_error.scss
+++ b/etc/css/custom/_page_error.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Page Error Styles | Custom [/etc/css/custom/page_error.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .page_error{
     min-height: 50vh;
     padding-top: 30px;

--- a/etc/css/custom/_page_gracias.scss
+++ b/etc/css/custom/_page_gracias.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Page Gracias Styles | Custom [/etc/css/custom/page_gracias.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .page_gracias{
     padding-bottom: 50px;
 }

--- a/etc/css/custom/_page_index.scss
+++ b/etc/css/custom/_page_index.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Page Index Styles | Custom [/etc/css/custom/page_index.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @import 'imp/page_index_fullHeight_imp';
 
 .page_index{

--- a/etc/css/custom/_popup.scss
+++ b/etc/css/custom/_popup.scss
@@ -2,6 +2,8 @@
    Popup Styles | Custom [/etc/css/custom/popup.scss]
    ========================================================================== */
     
+@use "sass:color";
+@use "sass:map";
 /* // Pop Modal ------------------------------------------------------------- */
 .modal_global{
     background-color: $modal_global_bgColour;

--- a/etc/css/custom/_print.scss
+++ b/etc/css/custom/_print.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Print Styles | Custom [/etc/css/custom/print.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @media print {
     @page{
         margin: 2cm;

--- a/etc/css/custom/_reset_custom.scss
+++ b/etc/css/custom/_reset_custom.scss
@@ -1,3 +1,5 @@
 /* * NombreDeProyecto * ========================================================
    Custom Reset Styles | Custom [/etc/css/custom/reset_custom.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";

--- a/etc/css/custom/_scrollbar.scss
+++ b/etc/css/custom/_scrollbar.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Scrollbar Styles | Custom [/etc/css/custom/scrollbar.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .scrollbar::-webkit-scrollbar{
   width: 12px;
   background-color: #eff1f5;

--- a/etc/css/custom/_shadows.scss
+++ b/etc/css/custom/_shadows.scss
@@ -2,6 +2,8 @@
    Shadows Classes | Custom [/etc/css/custom/shadows.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_slider.scss
+++ b/etc/css/custom/_slider.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Slider Styles | Custom [/etc/css/custom/slider.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .slick,
 .slick_with_nav{
     background-color: $slider_global_bgColour;

--- a/etc/css/custom/_slider_nav.scss
+++ b/etc/css/custom/_slider_nav.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Slider Nav Styles | Custom [/etc/css/custom/slider_nav.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .slick_nav{
     .slick-list{
         margin-right: $auto;

--- a/etc/css/custom/_social.scss
+++ b/etc/css/custom/_social.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Social Styles | Custom [/etc/css/custom/social.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .social{
     z-index: $zIndex_social;
         

--- a/etc/css/custom/_tables.scss
+++ b/etc/css/custom/_tables.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Tables Styles | Custom [/etc/css/custom/tables.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 table{
     th,
     tfoot td{

--- a/etc/css/custom/_text.scss
+++ b/etc/css/custom/_text.scss
@@ -2,6 +2,8 @@
    Settings Text | Custom [/etc/css/custom/text.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/custom/_wp_styles.scss
+++ b/etc/css/custom/_wp_styles.scss
@@ -1,4 +1,6 @@
 /* * NombreDeProyecto * ========================================================
    WordPress Styles | Custom [/etc/css/custom/wp_styles.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 .wp_styles{}

--- a/etc/css/custom/act/_buttons_act.scss
+++ b/etc/css/custom/act/_buttons_act.scss
@@ -2,6 +2,8 @@
    Buttons Activators | Custom [/etc/css/custom/act/buttons_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para botones.
 //

--- a/etc/css/custom/act/_classes_useful_act.scss
+++ b/etc/css/custom/act/_classes_useful_act.scss
@@ -2,6 +2,8 @@
    Useful Classes Activators | Custom [/etc/css/custom/act/classes_useful_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para clases useful.
 //

--- a/etc/css/custom/act/_fonts_act.scss
+++ b/etc/css/custom/act/_fonts_act.scss
@@ -2,6 +2,8 @@
    Fonts Activators | Custom [/etc/css/custom/act/fonts_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para fuentes.
 //

--- a/etc/css/custom/act/_footer_act.scss
+++ b/etc/css/custom/act/_footer_act.scss
@@ -2,6 +2,8 @@
    Footer Activators | Custom [/etc/css/custom/act/footer_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables activadoras.
 //

--- a/etc/css/custom/act/_form_act.scss
+++ b/etc/css/custom/act/_form_act.scss
@@ -2,6 +2,8 @@
    Forms activators | Custom [/etc/css/custom/act/form_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para elementos de form.
 //

--- a/etc/css/custom/act/_google_act.scss
+++ b/etc/css/custom/act/_google_act.scss
@@ -2,6 +2,8 @@
    Google Activators | Custom [/etc/css/custom/act/google_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables activadoras para elementos de Google.
 //

--- a/etc/css/custom/act/_header_act.scss
+++ b/etc/css/custom/act/_header_act.scss
@@ -2,6 +2,8 @@
    Header Activators | Custom [/etc/css/custom/act/header_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para Section Header.
 

--- a/etc/css/custom/act/_logo_act.scss
+++ b/etc/css/custom/act/_logo_act.scss
@@ -2,6 +2,8 @@
    Logo Activators | Custom [/etc/css/custom/act/logo_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para logo.
 //

--- a/etc/css/custom/act/_nav_lang_act.scss
+++ b/etc/css/custom/act/_nav_lang_act.scss
@@ -2,6 +2,8 @@
    Nav Activators | Custom [/etc/css/custom/act/nav_lang_act.scss]
    ========================================================================== */ 
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables activadoras.
 //

--- a/etc/css/custom/act/_nav_main_act.scss
+++ b/etc/css/custom/act/_nav_main_act.scss
@@ -2,6 +2,8 @@
    Nav Activators | Custom [/etc/css/custom/act/nav_main_act.scss]
    ========================================================================== */ 
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables activadoras.
 //

--- a/etc/css/custom/act/_page_index_act.scss
+++ b/etc/css/custom/act/_page_index_act.scss
@@ -2,6 +2,8 @@
    Page Index Activators | Custom [/etc/css/custom/act/page_index_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Activadores para Page Index.
 //

--- a/etc/css/custom/act/_page_section_act.scss
+++ b/etc/css/custom/act/_page_section_act.scss
@@ -2,6 +2,8 @@
    Page section Activators | Custom [/etc/css/custom/act/page_section_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables activadoras para el selector `#main section`.
 

--- a/etc/css/custom/act/_slider_act.scss
+++ b/etc/css/custom/act/_slider_act.scss
@@ -2,6 +2,8 @@
    Slider Activators | Custom [/etc/css/custom/act/slider_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Este archivo contiene las variables de activacion para generar los estilos
 // de flechas, flechas para carruseles e indicadores de pagina o "slide activo".

--- a/etc/css/custom/act/_text_act.scss
+++ b/etc/css/custom/act/_text_act.scss
@@ -2,6 +2,8 @@
    Text Activators | Custom [/etc/css/custom/act/text_act.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables activadoras para texto en general.
 //

--- a/etc/css/custom/css_post.scss
+++ b/etc/css/custom/css_post.scss
@@ -2,6 +2,8 @@
    CSS Styles Post | Custom [/etc/css/custom/css_post.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Post ------------------------------------------------------------------ */
 // REF [26]
 //@import "../scss/settings_lightbox";

--- a/etc/css/custom/css_pre.scss
+++ b/etc/css/custom/css_pre.scss
@@ -2,6 +2,8 @@
    CSS Styles Pre | Custom [/etc/css/custom/css_pre.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Activators ------------------------------------------------------------ */
 @import "act/classes_useful_act";
 @import "act/logo_act";

--- a/etc/css/custom/imp/_footer_fullHeight_imp.scss
+++ b/etc/css/custom/imp/_footer_fullHeight_imp.scss
@@ -2,6 +2,8 @@
    Footer Full Height Styles | Custom [/etc/css/custom/imp/footer_fullHeight_imp.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 // Imported in `[/etc/css/custom/_footer.scss]`

--- a/etc/css/custom/imp/_header_fullHeight_imp.scss
+++ b/etc/css/custom/imp/_header_fullHeight_imp.scss
@@ -2,6 +2,8 @@
    Header Full Height Styles | Custom [/etc/css/custom/imp/header_fullHeight_imp.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 // Imported in `[/etc/css/custom/_header.scss]`

--- a/etc/css/custom/imp/_header_headerFixed_imp.scss
+++ b/etc/css/custom/imp/_header_headerFixed_imp.scss
@@ -2,6 +2,8 @@
    Header Fixed Styles | Custom [/etc/css/custom/imp/header_headerFixed_imp.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 // Imported in `[/etc/css/custom/_header.scss]`

--- a/etc/css/custom/imp/_page_headerFixed_imp.scss
+++ b/etc/css/custom/imp/_page_headerFixed_imp.scss
@@ -2,6 +2,8 @@
    Page Int Section Full Height Styles | Custom [/etc/css/custom/imp/page_headerFixed_imp.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 // Imported in `[/etc/css/custom/_global.scss]`

--- a/etc/css/custom/imp/_page_index_fullHeight_imp.scss
+++ b/etc/css/custom/imp/_page_index_fullHeight_imp.scss
@@ -2,6 +2,8 @@
    Page Index Full Height Styles | Custom [/etc/css/custom/imp/page_index_fullHeight_imp.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 // Imported in `[/etc/css/custom/_page_index.scss]`

--- a/etc/css/custom/imp/_page_section_fullHeight_imp.scss
+++ b/etc/css/custom/imp/_page_section_fullHeight_imp.scss
@@ -2,6 +2,8 @@
    Page Int Section Full Height Styles | Custom [/etc/css/custom/imp/page_section_fullHeight_imp.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 // Imported in `[/etc/css/custom/_global.scss]`

--- a/etc/css/custom/style.scss
+++ b/etc/css/custom/style.scss
@@ -11,6 +11,8 @@ License:  GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html                 
 */
 
+@use "sass:color";
+@use "sass:map";
 @import "../scss/charset";
 @import "var/env_var";
 

--- a/etc/css/custom/styles_main.scss
+++ b/etc/css/custom/styles_main.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    CSS Styles Main | Custom [/etc/css/custom/styles_main.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 @import "../scss/charset";
 @import "var/env_var";
 

--- a/etc/css/custom/var/__colours_main_var.scss
+++ b/etc/css/custom/var/__colours_main_var.scss
@@ -2,6 +2,8 @@
    Colours CSS RGB Variables | Custom [/etc/css/custom/var/colours_css_rgb_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/__fonts_main_zh_var.scss
+++ b/etc/css/custom/var/__fonts_main_zh_var.scss
@@ -2,6 +2,8 @@
    Fonts Main Variables | Custom [/etc/css/custom/var/fonts_main_zh_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables de fuentes.
 // Contiene mapas de fuentes.
@@ -56,7 +58,7 @@ $font_families_map:(
 //
 // También se usa para asignar valor a la variable de cada fuente.
 // Ej.
-// $timesNewRoman: map-get($font_families_map, timesNewRoman), $font_families_serif_list_fallback;
+// $timesNewRoman: map.get($font_families_map, timesNewRoman), $font_families_serif_list_fallback;
 // font-family: $timesNewRoman;
 
     arial:          'mingliuregular',
@@ -83,9 +85,9 @@ $font_weights_map:(
 // `ftFamily_` regular y bold
 // REF [46] Fuentes Regular y Bold
 
-$arial:         map-get($font_families_map, arial);
-$roboto:        map-get($font_families_map, roboto);
-//$timesNewRoman: map-get($font_families_map, timesNewRoman);
-//$monospacedFont: map-get($font_families_map, monospacedFont);
-//$ming:              map-get($font_families_map, ming); // REF [14a]
-//$pming:             map-get($font_families_map, pming); // REF [14a]
+$arial:         map.get($font_families_map, arial);
+$roboto:        map.get($font_families_map, roboto);
+//$timesNewRoman: map.get($font_families_map, timesNewRoman);
+//$monospacedFont: map.get($font_families_map, monospacedFont);
+//$ming:              map.get($font_families_map, ming); // REF [14a]
+//$pming:             map.get($font_families_map, pming); // REF [14a]

--- a/etc/css/custom/var/__text_zh_var.scss
+++ b/etc/css/custom/var/__text_zh_var.scss
@@ -2,6 +2,8 @@
    Text Variables | Custom [/etc/css/custom/var/text_zh_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables de texto. Declaraciones de fuentes,
 // variables de pesos, interlinea, cuerpos tipograficos y espaciado general.

--- a/etc/css/custom/var/_animation_var.scss
+++ b/etc/css/custom/var/_animation_var.scss
@@ -2,6 +2,8 @@
    Animation Variables | Custom [/etc/css/custom/var/animation_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Contiene las variables para la propiedad `animation-delay` de las
 // animaciones del sitio. El orden de delay es el orden en el que se animan

--- a/etc/css/custom/var/_button_nav_hamburger_var.scss
+++ b/etc/css/custom/var/_button_nav_hamburger_var.scss
@@ -2,6 +2,8 @@
    Button Nav Hamburger Variables | Custom [/etc/css/custom/var/button_nav_hamburger_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_buttons_var.scss
+++ b/etc/css/custom/var/_buttons_var.scss
@@ -2,6 +2,8 @@
    Buttons Variables | Custom [/etc/css/custom/var/buttons_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_colours_backgrounds_var.scss
+++ b/etc/css/custom/var/_colours_backgrounds_var.scss
@@ -2,6 +2,8 @@
    Background Colours Variables | Custom [/etc/css/custom/var/colours_backgrounds_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 // Contiene mapas de colores.
@@ -57,7 +59,7 @@ $colours_backgrounds_map:(
 //
 // También se usa para asignar valor a la variable de cada color de fondo.
 // Ej.
-// $bgBlack: map-get($colours_backgrounds_map, Black);
+// $bgBlack: map.get($colours_backgrounds_map, Black);
 // background-color: $bgBlack;
 
 
@@ -94,37 +96,37 @@ $colours_backgrounds_map:(
     Error:          $errorColour
 );
 
-$bgError:           map-get($colours_backgrounds_map, Error);
+$bgError:           map.get($colours_backgrounds_map, Error);
 
-$bgWhite:           map-get($colours_backgrounds_map, White);
-$bgBlack:           map-get($colours_backgrounds_map, Black);
+$bgWhite:           map.get($colours_backgrounds_map, White);
+$bgBlack:           map.get($colours_backgrounds_map, Black);
 
-//$bgGreenSystem4XL:  map-get($colours_backgrounds_map, GreenSystem4XL);
-//$bgGreenSystem3XL:  map-get($colours_backgrounds_map, GreenSystem3XL);
-//$bgGreenSystem2XL:  map-get($colours_backgrounds_map, GreenSystem2XL);
-//$bgGreenSystemXL:   map-get($colours_backgrounds_map, GreenSystemXL);
-//$bgGreenSystemL:    map-get($colours_backgrounds_map, GreenSystemL);
-$bgGreenSystemM:    map-get($colours_backgrounds_map, GreenSystemM);
+//$bgGreenSystem4XL:  map.get($colours_backgrounds_map, GreenSystem4XL);
+//$bgGreenSystem3XL:  map.get($colours_backgrounds_map, GreenSystem3XL);
+//$bgGreenSystem2XL:  map.get($colours_backgrounds_map, GreenSystem2XL);
+//$bgGreenSystemXL:   map.get($colours_backgrounds_map, GreenSystemXL);
+//$bgGreenSystemL:    map.get($colours_backgrounds_map, GreenSystemL);
+$bgGreenSystemM:    map.get($colours_backgrounds_map, GreenSystemM);
 
-$bgGreenWhatsApp:   map-get($colours_backgrounds_map, GreenWhatsApp);
+$bgGreenWhatsApp:   map.get($colours_backgrounds_map, GreenWhatsApp);
 
-$bgGrey4XL:         map-get($colours_backgrounds_map, Grey4XL);
-$bgGrey3XL:         map-get($colours_backgrounds_map, Grey3XL);
-$bgGrey2XL:         map-get($colours_backgrounds_map, Grey2XL);
-$bgGreyXL:          map-get($colours_backgrounds_map, GreyXL);
-$bgGreyL:           map-get($colours_backgrounds_map, GreyL);
-$bgGreyM:           map-get($colours_backgrounds_map, GreyM);
-$bgGreyD:           map-get($colours_backgrounds_map, GreyD);
-$bgGreyXD:          map-get($colours_backgrounds_map, GreyXD);
-$bgGrey2XD:         map-get($colours_backgrounds_map, Grey2XD);
-$bgGrey3XD:         map-get($colours_backgrounds_map, Grey3XD);
+$bgGrey4XL:         map.get($colours_backgrounds_map, Grey4XL);
+$bgGrey3XL:         map.get($colours_backgrounds_map, Grey3XL);
+$bgGrey2XL:         map.get($colours_backgrounds_map, Grey2XL);
+$bgGreyXL:          map.get($colours_backgrounds_map, GreyXL);
+$bgGreyL:           map.get($colours_backgrounds_map, GreyL);
+$bgGreyM:           map.get($colours_backgrounds_map, GreyM);
+$bgGreyD:           map.get($colours_backgrounds_map, GreyD);
+$bgGreyXD:          map.get($colours_backgrounds_map, GreyXD);
+$bgGrey2XD:         map.get($colours_backgrounds_map, Grey2XD);
+$bgGrey3XD:         map.get($colours_backgrounds_map, Grey3XD);
 
-//$bgRedColourM:      map-get($colours_backgrounds_map, RedColourM);
+//$bgRedColourM:      map.get($colours_backgrounds_map, RedColourM);
     
-$bgStatusInfo:     map-get($colours_backgrounds_map, StatusInfo);
-$bgStatusOk:       map-get($colours_backgrounds_map, StatusOk);
-$bgStatusWarning:  map-get($colours_backgrounds_map, StatusWarning);
-$bgStatusError:    map-get($colours_backgrounds_map, StatusError);
+$bgStatusInfo:     map.get($colours_backgrounds_map, StatusInfo);
+$bgStatusOk:       map.get($colours_backgrounds_map, StatusOk);
+$bgStatusWarning:  map.get($colours_backgrounds_map, StatusWarning);
+$bgStatusError:    map.get($colours_backgrounds_map, StatusError);
     
 /*___ Declaramos las var para colores de fondo _*/
 $body_bgColour:         $bgGrey4XL;
@@ -140,8 +142,8 @@ $colours_backgrounds_hover_map:(
 // *.bgBlack:focus, *.bgBlack:hover{background-color: #hex}
 
 
-    mainBgColour: darken($bgColour_neutral, 20%),
-/*    bgGrey: lighten($bgGreyM, 20%)*/
+    mainBgColour: color.adjust($bgColour_neutral, $lightness: -20%),
+/*    bgGrey: color.adjust($bgGreyM, $lightness: 20%)*/
 );
 
-//$bgBlue_hover: map-get($colours_backgrounds_hover_map, bgBlue);
+//$bgBlue_hover: map.get($colours_backgrounds_hover_map, bgBlue);

--- a/etc/css/custom/var/_colours_borders_var.scss
+++ b/etc/css/custom/var/_colours_borders_var.scss
@@ -2,6 +2,8 @@
    Border Colours Variables | Custom [/etc/css/custom/var/colours_borders_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 
@@ -78,39 +80,39 @@ $colours_borders_map:(
     outline:        #c6c6c6
 );
  
-$bdError:           map-get($colours_borders_map, error);
-$bdOutline:         map-get($colours_borders_map, outline);
+$bdError:           map.get($colours_borders_map, error);
+$bdOutline:         map.get($colours_borders_map, outline);
 
-$bdWhite:           map-get($colours_borders_map, white);
-$bdBlack:           map-get($colours_borders_map, black);
+$bdWhite:           map.get($colours_borders_map, white);
+$bdBlack:           map.get($colours_borders_map, black);
 
-//$bdGreenSystem4XL:  map-get($colours_borders_map, greenSystem4XL);
-//$bdGreenSystem3XL:  map-get($colours_borders_map, greenSystem3XL);
-//$bdGreenSystem2XL:  map-get($colours_borders_map, greenSystem2XL);
-//$bdGreenSystemXL:   map-get($colours_borders_map, greenSystemXL);
-//$bdGreenSystemL:    map-get($colours_borders_map, greenSystemL);
-//$bdGreenSystem:     map-get($colours_borders_map, greenSystem);
+//$bdGreenSystem4XL:  map.get($colours_borders_map, greenSystem4XL);
+//$bdGreenSystem3XL:  map.get($colours_borders_map, greenSystem3XL);
+//$bdGreenSystem2XL:  map.get($colours_borders_map, greenSystem2XL);
+//$bdGreenSystemXL:   map.get($colours_borders_map, greenSystemXL);
+//$bdGreenSystemL:    map.get($colours_borders_map, greenSystemL);
+//$bdGreenSystem:     map.get($colours_borders_map, greenSystem);
 
-$bdGrey4XL:         map-get($colours_borders_map, grey4XL);
-$bdGrey3XL:         map-get($colours_borders_map, grey3XL);
-$bdGrey2XL:         map-get($colours_borders_map, grey2XL);
-$bdGreyXL:          map-get($colours_borders_map, greyXL);
-$bdGreyL:           map-get($colours_borders_map, greyL);
-$bdGreyM:           map-get($colours_borders_map, greyM);
-$bdGreyD:           map-get($colours_borders_map, greyD);
-$bdGreyXD:          map-get($colours_borders_map, greyXD);
-$bdGrey2XD:         map-get($colours_borders_map, grey2XD);
-//$bdGrey3XD:         map-get($colours_borders_map, grey3XD);
+$bdGrey4XL:         map.get($colours_borders_map, grey4XL);
+$bdGrey3XL:         map.get($colours_borders_map, grey3XL);
+$bdGrey2XL:         map.get($colours_borders_map, grey2XL);
+$bdGreyXL:          map.get($colours_borders_map, greyXL);
+$bdGreyL:           map.get($colours_borders_map, greyL);
+$bdGreyM:           map.get($colours_borders_map, greyM);
+$bdGreyD:           map.get($colours_borders_map, greyD);
+$bdGreyXD:          map.get($colours_borders_map, greyXD);
+$bdGrey2XD:         map.get($colours_borders_map, grey2XD);
+//$bdGrey3XD:         map.get($colours_borders_map, grey3XD);
 
-//$bdRedColourM:      map-get($colours_borders_map, redColourM);
+//$bdRedColourM:      map.get($colours_borders_map, redColourM);
  
-$bdStatusInfo:     map-get($colours_borders_map, statusInfo);
-$bdStatusOk:       map-get($colours_borders_map, statusOk);
-$bdStatusWarning:  map-get($colours_borders_map, statusWarning);
-$bdStatusError:    map-get($colours_borders_map, statusError);
+$bdStatusInfo:     map.get($colours_borders_map, statusInfo);
+$bdStatusOk:       map.get($colours_borders_map, statusOk);
+$bdStatusWarning:  map.get($colours_borders_map, statusWarning);
+$bdStatusError:    map.get($colours_borders_map, statusError);
 
 $bdColour_main_global:              $bdGreyM;
-$bdColour_main_global_hover:        darken($bdColour_main_global, 15%);
+$bdColour_main_global_hover:        color.adjust($bdColour_main_global, $lightness: -15%);
 
 $bdColour_secondary_global:         $bdGreyXD;
-$bdColour_secondary_global_hover:   darken($bdColour_main_global, 15%);
+$bdColour_secondary_global_hover:   color.adjust($bdColour_main_global, $lightness: -15%);

--- a/etc/css/custom/var/_colours_main_var.scss
+++ b/etc/css/custom/var/_colours_main_var.scss
@@ -2,6 +2,8 @@
    Colours Main Variables | Custom [/etc/css/custom/var/colours_main_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 
@@ -95,10 +97,10 @@ $colours_dark_map:(
 );
 $colours_dark_lightenValue: 20%;
 
-$colours_merged_map: map-merge($colours_light_map, $colours_dark_map);
+$colours_merged_map: map.merge($colours_light_map, $colours_dark_map);
 
 $white:             #fff;
-$white_hover:       darken($white, 10%);
+$white_hover:       color.adjust($white, $lightness: -10%);
 $white_rgba:        rgb(255, 255, 255);
 $white_rgba_10:     rgba($white_rgba, 0.1);
 $white_rgba_20:     rgba($white_rgba, 0.2);
@@ -111,7 +113,7 @@ $white_rgba_80:     rgba($white_rgba, 0.8);
 $white_rgba_85:     rgba($white_rgba, 0.85);
 $white_rgba_90:     rgba($white_rgba, 0.9);
 
-$black:             map-get($colours_merged_map, black);
+$black:             map.get($colours_merged_map, black);
 $black_rgba:        rgb(0, 0, 0);
 $black_rgba_10:     rgba($black_rgba, 0.1);
 $black_rgba_20:     rgba($black_rgba, 0.2);
@@ -123,53 +125,53 @@ $black_rgba_70:     rgba($black_rgba, 0.7);
 $black_rgba_80:     rgba($black_rgba, 0.8);
 $black_rgba_90:     rgba($black_rgba, 0.9);
 
-//$errorColour4XL:    map-get($colours_merged_map, errorColour4XL);
-//$errorColourXL:    map-get($colours_merged_map, errorColourXL);
-$errorColour:       map-get($colours_merged_map, errorColour);
+//$errorColour4XL:    map.get($colours_merged_map, errorColour4XL);
+//$errorColourXL:    map.get($colours_merged_map, errorColourXL);
+$errorColour:       map.get($colours_merged_map, errorColour);
 $errorColour_rgba:      rgb(235, 28, 36);
 $errorColour_rgba_40:   rgba($errorColour_rgba, 0.4);
 $errorColour_rgba_70:   rgba($errorColour_rgba, 0.7);
 
-//$greenSystem4XL:    map-get($colours_merged_map, greenSystem4XL);
-//$greenSystem3XL:    map-get($colours_merged_map, greenSystem3XL);
-//$greenSystem2XL:    map-get($colours_merged_map, greenSystem2XL);
-//$greenSystemXL:     map-get($colours_merged_map, greenSystemXL);
-//$greenSystemL:      map-get($colours_merged_map, greenSystemL);
-$greenSystemM:      map-get($colours_merged_map, greenSystemM);
-//$greenSystemD:      map-get($colours_merged_map, greenSystemD);
+//$greenSystem4XL:    map.get($colours_merged_map, greenSystem4XL);
+//$greenSystem3XL:    map.get($colours_merged_map, greenSystem3XL);
+//$greenSystem2XL:    map.get($colours_merged_map, greenSystem2XL);
+//$greenSystemXL:     map.get($colours_merged_map, greenSystemXL);
+//$greenSystemL:      map.get($colours_merged_map, greenSystemL);
+$greenSystemM:      map.get($colours_merged_map, greenSystemM);
+//$greenSystemD:      map.get($colours_merged_map, greenSystemD);
 
-$greenWhatsApp:         map-get($colours_merged_map, greenWhatsApp);
-$greenWhatsApp_hover:   darken($greenWhatsApp, 5%);
+$greenWhatsApp:         map.get($colours_merged_map, greenWhatsApp);
+$greenWhatsApp_hover:   color.adjust($greenWhatsApp, $lightness: -5%);
 
-$grey5XL:           map-get($colours_merged_map, grey5XL);
-$grey4XL:           map-get($colours_merged_map, grey4XL);
-$grey3XL:           map-get($colours_merged_map, grey3XL);
+$grey5XL:           map.get($colours_merged_map, grey5XL);
+$grey4XL:           map.get($colours_merged_map, grey4XL);
+$grey3XL:           map.get($colours_merged_map, grey3XL);
 $grey3XL_rgba:      rgb(422, 242, 242);
 $grey3XL_rgba_70:   rgba($grey3XL_rgba, 0.7);
-$grey2XL:           map-get($colours_merged_map, grey2XL);
-$greyXL:            map-get($colours_merged_map, greyXL);
+$grey2XL:           map.get($colours_merged_map, grey2XL);
+$greyXL:            map.get($colours_merged_map, greyXL);
 $greyXL_rgba:       rgb(222, 222, 222);
 $greyXL_rgba_00:    rgba($greyXL_rgba, 0); // REF [16]
-$greyL:             map-get($colours_merged_map, greyL);
+$greyL:             map.get($colours_merged_map, greyL);
 $greyL_rgba:        rgb(178, 178, 178);
 $greyL_rgba_20:     rgba($greyL_rgba, 0.2);
 $greyL_rgba_50:     rgba($greyL_rgba, 0.5);
-$greyM:             map-get($colours_merged_map, greyM);
-$greyD:             map-get($colours_merged_map, greyD);
-$greyXD:            map-get($colours_merged_map, greyXD);
-$grey2XD:           map-get($colours_merged_map, grey2XD);
+$greyM:             map.get($colours_merged_map, greyM);
+$greyD:             map.get($colours_merged_map, greyD);
+$greyXD:            map.get($colours_merged_map, greyXD);
+$grey2XD:           map.get($colours_merged_map, grey2XD);
 $grey2XD_rgba:      rgb(51, 51, 51);
 $grey2XD_rgba_90:   rgba($grey2XD_rgba, 0.9);
-$grey3XD:           map-get($colours_merged_map, grey3XD);
-$grey4XD:           map-get($colours_merged_map, grey4XD);
-$grey5XD:           map-get($colours_merged_map, grey5XD);
+$grey3XD:           map.get($colours_merged_map, grey3XD);
+$grey4XD:           map.get($colours_merged_map, grey4XD);
+$grey5XD:           map.get($colours_merged_map, grey5XD);
 
-//$redColourM:        map-get($colours_merged_map, redColourM);
+//$redColourM:        map.get($colours_merged_map, redColourM);
 
-$statusInfo:     map-get($colours_merged_map, statusInfo);
-$statusOk:       map-get($colours_merged_map, statusOk);
-$statusWarning:  map-get($colours_merged_map, statusWarning);
-$statusError:    map-get($colours_merged_map, statusError);
+$statusInfo:     map.get($colours_merged_map, statusInfo);
+$statusOk:       map.get($colours_merged_map, statusOk);
+$statusWarning:  map.get($colours_merged_map, statusWarning);
+$statusError:    map.get($colours_merged_map, statusError);
 
 ///**Anchor Colours Light:** 
     ///Aquí se agregan los colores para las anclas dentro de un párrafo con color CLARO, de este mapa se creara una clase por cada color con el mixin **anchorColoursLightClassesGenerator** `[/etc/scss/coloursMixins.scss]`. Se creara el sig. CSS por cada color, eg.: `.white a{color: #fff}`. Generará las pseudo-clases `:active` y `:visited` con el mismo valor. Las pseudo-clases `:focus` y `:hover` aclararán el color con el porcentaje asignado en la variable `$colours_anchor_ftColours_light_lightenValue` debajo del mapa. 

--- a/etc/css/custom/var/_container_sizes_var.scss
+++ b/etc/css/custom/var/_container_sizes_var.scss
@@ -2,6 +2,8 @@
    Container Sizes Variables | Custom [/etc/css/custom/var/container_sizes_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_env_var.scss
+++ b/etc/css/custom/var/_env_var.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Variables de Entorno | Custom [/etc/css/custom/var/_env_var.scss]
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 $dir_env-altTest:          "/x/test";
 $dir_env-altStage:         "/x/stage";
 $dir_env-altProduccion:    "/x";

--- a/etc/css/custom/var/_fonts_main_var.scss
+++ b/etc/css/custom/var/_fonts_main_var.scss
@@ -2,6 +2,8 @@
    Fonts Main Variables | Custom [/etc/css/custom/var/fonts_main_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables de fuentes.
 // Contiene mapas de fuentes.
@@ -54,7 +56,7 @@ $font_families_map:(
 //
 // También se usa para asignar valor a la variable de cada fuente.
 // Ej.
-// $timesNewRoman: map-get($font_families_map, timesNewRoman), $font_families_serif_list_fallback;
+// $timesNewRoman: map.get($font_families_map, timesNewRoman), $font_families_serif_list_fallback;
 // font-family: $timesNewRoman;
 //
 // REF [01] Las Google Fonts no deben ser declaradas en este mapa.
@@ -75,7 +77,7 @@ $font_weights_map:(
 //
 // Tambien se usa para generar las variables de peso `_w`
 // Ej.
-// $ralewayXB_w:      map-get($font_weights_map, ralewayXB);
+// $ralewayXB_w:      map.get($font_weights_map, ralewayXB);
 
 
 //    ralewayM:       500,
@@ -89,17 +91,17 @@ $font_weights_map:(
 // `ftFamily_` regular y bold
 // REF [46] Fuentes Regular y Bold
 
-$arial:             map-get($font_families_map, arial), $font_families_sans_list_fallback;
-$roboto:            map-get($font_families_map, roboto), $font_families_sans_list_fallback;
+$arial:             map.get($font_families_map, arial), $font_families_sans_list_fallback;
+$roboto:            map.get($font_families_map, roboto), $font_families_sans_list_fallback;
 $ftSansSerif:     $font_families_sans_list_fallback;
 
-//$timesNewRoman:     map-get($font_families_map, timesNewRoman), $font_families_serif_list_fallback;
+//$timesNewRoman:     map.get($font_families_map, timesNewRoman), $font_families_serif_list_fallback;
 $ftSerif:           $font_families_serif_list_fallback;
 
-//$monospacedFont:    map-get($font_families_map, monospacedFont), $font_families_monospaced_list_fallback;
+//$monospacedFont:    map.get($font_families_map, monospacedFont), $font_families_monospaced_list_fallback;
 $ftMonospaced:    $font_families_monospaced_list_fallback;
 
-$consolas:          map-get($font_families_map, consolas), $font_families_monospaced_list_fallback;
+$consolas:          map.get($font_families_map, consolas), $font_families_monospaced_list_fallback;
 
 // REF [01] Las Google Fonts deben ser declaradas de la siguiente forma:
 
@@ -107,6 +109,6 @@ $consolas:          map-get($font_families_map, consolas), $font_families_monosp
 //$ralewaySB:        'Raleway', $font_families_sans_list_fallback;
 //$ralewayXB:        'Raleway', $font_families_sans_list_fallback;
 
-//$ralewayM_w:       map-get($font_weights_map, ralewayM);
-//$ralewaySB_w:      map-get($font_weights_map, ralewaySB);
-//$ralewayXB_w:      map-get($font_weights_map, ralewayXB);
+//$ralewayM_w:       map.get($font_weights_map, ralewayM);
+//$ralewaySB_w:      map.get($font_weights_map, ralewaySB);
+//$ralewayXB_w:      map.get($font_weights_map, ralewayXB);

--- a/etc/css/custom/var/_footer_var.scss
+++ b/etc/css/custom/var/_footer_var.scss
@@ -2,6 +2,8 @@
    Footer Variables | Custom [/etc/css/custom/var/footer_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Full heights Footer --------------------------------------------------- */
 $footer_height_ALL:     100px;
 $footer_height_B500:      101px;

--- a/etc/css/custom/var/_form_colours_var.scss
+++ b/etc/css/custom/var/_form_colours_var.scss
@@ -2,6 +2,8 @@
    Form Colours Variables | Custom [/etc/css/custom/var/form_colours_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables de colores de texto de los elementos `label`,
 // `input`, `placeholder` y `submit` con sus `:hover`.
@@ -55,15 +57,15 @@
      
 /* // Form Label ------------------------------------------------------------ */
 $form_label_ftColour:           $ftColour_main_global;
-$form_label_ftColour_hover:     darken($form_label_ftColour, 15%);
+$form_label_ftColour_hover:     color.adjust($form_label_ftColour, $lightness: -15%);
     
      
 /* // Forms Input ----------------------------------------------------------- */
 $form_input_ftColour:           $ftColour_main_global;
 $form_input_ftColour_hover:     $form_input_ftColour;
 
-$form_placeholder_ftColour:         lighten($form_input_ftColour, 10%); // REF [10]
-$form_placeholder_ftColour_hover:   darken($form_placeholder_ftColour, 5%); // REF [10]
+$form_placeholder_ftColour:         color.adjust($form_input_ftColour, $lightness: 10%); // REF [10]
+$form_placeholder_ftColour_hover:   color.adjust($form_placeholder_ftColour, $lightness: -5%); // REF [10]
  
 $form_input_ftColour_autofill:  $form_input_ftColour;
   

--- a/etc/css/custom/var/_form_fonts_var.scss
+++ b/etc/css/custom/var/_form_fonts_var.scss
@@ -2,6 +2,8 @@
    Form Fonts Variables | Custom [/etc/css/custom/var/form_fonts_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Referencias globales de nombres de variables y mixins ----------------- */
 ///-- Inicio del nombre
 // bd                   = borde

--- a/etc/css/custom/var/_form_sizes_var.scss
+++ b/etc/css/custom/var/_form_sizes_var.scss
@@ -2,6 +2,8 @@
    Form Sizes Variables | Custom [/etc/css/custom/var/form_sizes_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_global_var.scss
+++ b/etc/css/custom/var/_global_var.scss
@@ -2,6 +2,8 @@
    Global Variables | Custom [/etc/css/custom/var/global_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_header_var.scss
+++ b/etc/css/custom/var/_header_var.scss
@@ -2,6 +2,8 @@
    Header Variables | Custom [/etc/css/custom/var/header_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_helpers_var.scss
+++ b/etc/css/custom/var/_helpers_var.scss
@@ -2,6 +2,8 @@
    Spacing Helpers Variables | Custom [/etc/css/custom/var/helpers.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Spacing --------------------------------------------------------------- */
 $helpers_spacing_PM_small:   5px!important;
 $helpers_spacing_PM_medium:  10px!important;

--- a/etc/css/custom/var/_hover_var.scss
+++ b/etc/css/custom/var/_hover_var.scss
@@ -2,6 +2,8 @@
    Hover Variables | Custom [/etc/css/custom/var/hover_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_lightbox_var.scss
+++ b/etc/css/custom/var/_lightbox_var.scss
@@ -2,6 +2,8 @@
    Lightbox Variables | Custom [/etc/css/custom/var/lightbox_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_lists_var.scss
+++ b/etc/css/custom/var/_lists_var.scss
@@ -2,6 +2,8 @@
    Lists Variables | Custom [/etc/css/custom/var/lists.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_logo_sizes_var.scss
+++ b/etc/css/custom/var/_logo_sizes_var.scss
@@ -2,6 +2,8 @@
    Logo Sizes Variables | Custom [/etc/css/custom/var/logo_sizes_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_mediaQueries_var.scss
+++ b/etc/css/custom/var/_mediaQueries_var.scss
@@ -2,6 +2,8 @@
    Media Queries values Variables | Custom [/etc/css/custom/var/mediaQueries_var.scss]
    ========================================================================== */ 
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de var de media queries.
 // REF [03]

--- a/etc/css/custom/var/_nav_arrows_var.scss
+++ b/etc/css/custom/var/_nav_arrows_var.scss
@@ -2,6 +2,8 @@
    Nav Arrows Backgrounds | Custom [/etc/css/custom/var/nav_arrows_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 $nav_arrows_TLI_level1_openDR:          "nav_arrow_down.svg";
 $nav_arrows_TLI_level2_openDR:          "nav_arrow_down.svg";
 $nav_arrows_TLI_level3_openDR:          "nav_arrow_down.svg";

--- a/etc/css/custom/var/_nav_colours_var.scss
+++ b/etc/css/custom/var/_nav_colours_var.scss
@@ -2,6 +2,8 @@
    Nav Colours Variables | Custom [/etc/css/custom/var/nav_colours_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 //
@@ -96,10 +98,10 @@ $nav_item_level1_bgColour_BT:           transparent;
 $nav_item_level2_bgColour_BT:           transparent;
 $nav_item_level3_bgColour_BT:           transparent;
 
-$nav_item_current_level0_bgColour_BT:   darken($nav_bgColour_BT, 5%);
-$nav_item_current_level1_bgColour_BT:   darken($nav_ul_level1_bgColour_BT, 5%);
-$nav_item_current_level2_bgColour_BT:   darken($nav_ul_level1_bgColour_BT, 5%);
-$nav_item_current_level3_bgColour_BT:   darken($nav_ul_level1_bgColour_BT, 5%);
+$nav_item_current_level0_bgColour_BT:   color.adjust($nav_bgColour_BT, $lightness: -5%);
+$nav_item_current_level1_bgColour_BT:   color.adjust($nav_ul_level1_bgColour_BT, $lightness: -5%);
+$nav_item_current_level2_bgColour_BT:   color.adjust($nav_ul_level1_bgColour_BT, $lightness: -5%);
+$nav_item_current_level3_bgColour_BT:   color.adjust($nav_ul_level1_bgColour_BT, $lightness: -5%);
 
 
 /*___ AT ________________________________*/
@@ -137,7 +139,7 @@ $nav_item_level1_bdColour_BT:       $nav_item_level0_bdColour_BT;
 $nav_item_level2_bdColour_BT:       $nav_item_level1_bdColour_BT;
 $nav_item_level3_bdColour_BT:       $nav_item_level2_bdColour_BT;
 
-$nav_subNav_borderB_BT:             darken($nav_ul_level1_bgColour_BT, 5%);
+$nav_subNav_borderB_BT:             color.adjust($nav_ul_level1_bgColour_BT, $lightness: -5%);
   
 $nav_bdColour_backMenu:             $nav_item_level1_bdColour_BT; // REF [17]
 

--- a/etc/css/custom/var/_nav_fonts_var.scss
+++ b/etc/css/custom/var/_nav_fonts_var.scss
@@ -2,6 +2,8 @@
    Nav Fonts Variables | Custom [/etc/css/custom/var/nav_fonts_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_nav_lang_var.scss
+++ b/etc/css/custom/var/_nav_lang_var.scss
@@ -2,6 +2,8 @@
    Nav Language Variables | Custom [/etc/css/custom/var/nav_lang_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 //

--- a/etc/css/custom/var/_nav_sizes_var.scss
+++ b/etc/css/custom/var/_nav_sizes_var.scss
@@ -2,6 +2,8 @@
    Nav Sizes Variables | Custom [/etc/css/custom/var/nav_sizes_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_page_construccion_var.scss
+++ b/etc/css/custom/var/_page_construccion_var.scss
@@ -2,6 +2,8 @@
    Page Construccion Variables | Custom [/etc/css/custom/var/page_construccion_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_page_contacto_var.scss
+++ b/etc/css/custom/var/_page_contacto_var.scss
@@ -2,6 +2,8 @@
    Page Contacto Variables | Custom [/etc/css/custom/var/page_contacto_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_page_index_var.scss
+++ b/etc/css/custom/var/_page_index_var.scss
@@ -2,6 +2,8 @@
    Page Index Variables | Custom [/etc/css/custom/var/page_index_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_page_xxx_var.scss
+++ b/etc/css/custom/var/_page_xxx_var.scss
@@ -2,6 +2,8 @@
    Page xxx Variables | Custom [/etc/css/custom/var/page_xxx_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_popup_var.scss
+++ b/etc/css/custom/var/_popup_var.scss
@@ -2,6 +2,8 @@
    Popup Variables | Custom [/etc/css/custom/var/popup_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_shadows_var.scss
+++ b/etc/css/custom/var/_shadows_var.scss
@@ -2,6 +2,8 @@
    Shadows Variables | Custom [/etc/css/custom/var/shadows_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_slider_var.scss
+++ b/etc/css/custom/var/_slider_var.scss
@@ -2,6 +2,8 @@
    Slider Variables | Custom [/etc/css/custom/var/slider_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_social_var.scss
+++ b/etc/css/custom/var/_social_var.scss
@@ -2,6 +2,8 @@
    Social Variables | Custom [/etc/css/custom/var/section_social_var.scss]
    ========================================================================== */
     
+@use "sass:color";
+@use "sass:map";
 /* // Social Sizes ---------------------------------------------------------- */
 $social_icon_size_B600:      30px;
 $social_icon_size_A600:      40px;

--- a/etc/css/custom/var/_tables_colours_var.scss
+++ b/etc/css/custom/var/_tables_colours_var.scss
@@ -2,6 +2,8 @@
    Tables Colours Variables | Custom [/etc/css/custom/var/tables_colours_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Table Border Colours -------------------------------------------------- */
 $table_bdColour_main:         $bdGreyM;
 $table_bdColour_sec:    $bdGreyXL;
@@ -17,4 +19,4 @@ $table_bgColour_ter:     $bgGreyXL;
 $table_bgColour_striped_thead:     #aaa;
 $table_bgColour_striped_odd:       #eee;
 $table_bgColour_striped_even:      $white;
-$table_bgColour_striped_separator: darken($table_bgColour_striped_odd, 60%);
+$table_bgColour_striped_separator: color.adjust($table_bgColour_striped_odd, $lightness: -60%);

--- a/etc/css/custom/var/_tables_var.scss
+++ b/etc/css/custom/var/_tables_var.scss
@@ -2,6 +2,8 @@
    Tables Variables | Custom [/etc/css/custom/var/tables.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_text_colours_var.scss
+++ b/etc/css/custom/var/_text_colours_var.scss
@@ -2,6 +2,8 @@
    Text Colour Variables | Custom [/etc/css/custom/var/text_colours_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables colores de texto y anclas.
 
@@ -49,10 +51,10 @@
 
 /* // Text Colours ---------------------------------------------------------- */
 $ftColour_main_global:          $black;
-$ftColour_main_global_hover:    lighten($ftColour_main_global, 20%);
+$ftColour_main_global_hover:    color.adjust($ftColour_main_global, $lightness: 20%);
 
 $ftColour_anchor_global:        $ftColour_main_global_hover;
-$ftColour_anchor_global_hover:  darken($ftColour_main_global_hover, 10%);
+$ftColour_anchor_global_hover:  color.adjust($ftColour_main_global_hover, $lightness: -10%);
 
 $txSelection_ftColour_global:   $ftColour_main_global;
 $txSelection_bgColour_global:   $bgColour_neutral;

--- a/etc/css/custom/var/_text_var.scss
+++ b/etc/css/custom/var/_text_var.scss
@@ -2,6 +2,8 @@
    Text Variables | Custom [/etc/css/custom/var/text_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables de texto. Declaraciones de fuentes,
 // variables de pesos, interlinea, cuerpos tipograficos y espaciado general.

--- a/etc/css/custom/var/_video_var.scss
+++ b/etc/css/custom/var/_video_var.scss
@@ -2,6 +2,8 @@
    Video Variables | Custom [/etc/css/custom/var/video_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/custom/var/_zindex_var.scss
+++ b/etc/css/custom/var/_zindex_var.scss
@@ -2,6 +2,8 @@
    Z Index Variables | Custom [/etc/css/custom/var/zindex_var.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 // REF [50] Google captcha
 
 /* // Negative -------------------------------------------------------------- */

--- a/etc/css/scss/charset.scss
+++ b/etc/css/scss/charset.scss
@@ -1,1 +1,3 @@
 @charset "UTF-8";
+@use "sass:color";
+@use "sass:map";

--- a/etc/css/scss/classes_useful_all.scss
+++ b/etc/css/scss/classes_useful_all.scss
@@ -2,6 +2,8 @@
    Useful Classes ALL | Etc [/etc/css/scss/classes_useful_all.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/classes_useful_responsive.scss
+++ b/etc/css/scss/classes_useful_responsive.scss
@@ -2,6 +2,8 @@
    Useful Classes Responsive | Etc [/etc/css/scss/classes_useful_responsive.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/functions_angledEdges.scss
+++ b/etc/css/scss/functions_angledEdges.scss
@@ -2,6 +2,8 @@
    Angled Edges Functions | Etc [/etc/css/scss/functions_angledEdges.scss]scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 //-------------------------------------------------------------------------------------
 // Angled Edges v2.0.0 (https://github.com/josephfusco/angled-edges)
 // Copyright 2017 Joseph Fusco
@@ -108,11 +110,11 @@
 	// capture alpha component of $fill_angledEdges_fn to use with fill-opacity
 	$fill_angledEdges_fn-alpha: alpha($fill_angledEdges_fn);
 
-	$wedge_angledEdges_fn: '<svg width="#{$width_angledEdges_fn}" height="#{$height_angledEdges_fn}" fill="#{$fill_angledEdges_fn-rgb}" fill-opacity="#{$fill_angledEdges_fn-alpha}"><polygon points="#{map-get($points_angledEdges_fn, $hypotenuse_angledEdges_fn)}"></polygon></svg>';
+	$wedge_angledEdges_fn: '<svg width="#{$width_angledEdges_fn}" height="#{$height_angledEdges_fn}" fill="#{$fill_angledEdges_fn-rgb}" fill-opacity="#{$fill_angledEdges_fn-alpha}"><polygon points="#{map.get($points_angledEdges_fn, $hypotenuse_angledEdges_fn)}"></polygon></svg>';
 
 	// full width wedge
 	@if ($width_angledEdges_fn == null) {
-		$wedge_angledEdges_fn: '<svg preserveAspectRatio="none" viewBox="0 0 100 #{$height_angledEdges_fn}" fill="#{$fill_angledEdges_fn-rgb}" fill-opacity="#{$fill_angledEdges_fn-alpha}"><polygon points="#{map-get($points_angledEdges_fn, $hypotenuse_angledEdges_fn)}"></polygon></svg>';
+		$wedge_angledEdges_fn: '<svg preserveAspectRatio="none" viewBox="0 0 100 #{$height_angledEdges_fn}" fill="#{$fill_angledEdges_fn-rgb}" fill-opacity="#{$fill_angledEdges_fn-alpha}"><polygon points="#{map.get($points_angledEdges_fn, $hypotenuse_angledEdges_fn)}"></polygon></svg>';
 	}
 
 	$encoded-wedge: ae-svg-encode($wedge_angledEdges_fn);

--- a/etc/css/scss/functions_fontStroke.scss
+++ b/etc/css/scss/functions_fontStroke.scss
@@ -2,6 +2,8 @@
    Font Stroke Functions | Etc [/etc/css/scss/functionsFontStroke.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_backgrounds.scss
+++ b/etc/css/scss/mixins_backgrounds.scss
@@ -2,6 +2,8 @@
    Background Mixins | Etc [/etc/css/scss/mixins_backgrounds.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_borders.scss
+++ b/etc/css/scss/mixins_borders.scss
@@ -2,6 +2,8 @@
    Border Helpers Mixins | Etc [/etc/css/scss/mixins_borders.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Este archivo contiene mixins para generar declaraciones de bordes.
 //

--- a/etc/css/scss/mixins_center.scss
+++ b/etc/css/scss/mixins_center.scss
@@ -2,6 +2,8 @@
    Center Mixins | Etc [/etc/css/scss/mixins_center.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_clearfix.scss
+++ b/etc/css/scss/mixins_clearfix.scss
@@ -2,6 +2,8 @@
    Mixin  Clearfix | Etc [/etc/css/scss/mixins_clearfix.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_clipPath.scss
+++ b/etc/css/scss/mixins_clipPath.scss
@@ -2,6 +2,8 @@
    Clip Paths Mixins | Etc [/etc/css/scss/mixinsClipPath.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_colours.scss
+++ b/etc/css/scss/mixins_colours.scss
@@ -2,6 +2,8 @@
    Colour Mixins | Etc [/etc/css/scss/mixins_colours.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Este archivo contiene los mixins para generar clases y selectores de colores.
 // Los mapas que se encuentran en `[/etc/css/custom/var/colours_main_var.scss]`.
@@ -149,12 +151,12 @@
         a.#{$colourLightClassesGeneratorMX_colourClassName}{
             &, &:active, &:visited, 
             &.noHover:focus, &.noHover:hover{color: $colourLightClassesGeneratorMX_colourHexValue;}
-            &:focus, &:focus-visible, &:hover{color: darken($colourLightClassesGeneratorMX_colourHexValue, $colours_light_lightenValue);}
+            &:focus, &:focus-visible, &:hover{color: color.adjust($colourLightClassesGeneratorMX_colourHexValue, $lightness: -$colours_light_lightenValue);}
         }
         @if $button_coloured_act == "on"{
             button.#{$colourLightClassesGeneratorMX_colourClassName}{
                 &, &.noHover:focus, &.noHover:hover{color: $colourLightClassesGeneratorMX_colourHexValue;}
-                &:focus, &:focus-visible, &:hover{color: darken($colourLightClassesGeneratorMX_colourHexValue, $colours_light_lightenValue);}
+                &:focus, &:focus-visible, &:hover{color: color.adjust($colourLightClassesGeneratorMX_colourHexValue, $lightness: -$colours_light_lightenValue);}
             }
         }
         @if $form_label_coloured_act == "on"{
@@ -172,12 +174,12 @@
         a.#{$colourDarkClassesGeneratorMX_colourClassName}{
             &, &:active, &:visited, 
             &.noHover:focus, &.noHover:hover{color: $colourDarkClassesGeneratorMX_colourHexValue;}
-            &:focus, &:focus-visible, &:hover{color: lighten($colourDarkClassesGeneratorMX_colourHexValue, $colours_dark_lightenValue);}
+            &:focus, &:focus-visible, &:hover{color: color.adjust($colourDarkClassesGeneratorMX_colourHexValue, $lightness: $colours_dark_lightenValue);}
         }
         @if $button_coloured_act == "on"{
             button.#{$colourDarkClassesGeneratorMX_colourClassName}{
                 &, &.noHover:focus, &.noHover:hover{color: $colourDarkClassesGeneratorMX_colourHexValue;}
-                &:focus, &:focus-visible, &:hover{color: lighten($colourDarkClassesGeneratorMX_colourHexValue, $colours_dark_lightenValue);}
+                &:focus, &:focus-visible, &:hover{color: color.adjust($colourDarkClassesGeneratorMX_colourHexValue, $lightness: $colours_dark_lightenValue);}
             }
         }
         @if $form_label_coloured_act == "on"{
@@ -191,7 +193,7 @@
     @each $anchorColoursLightClassesGeneratorMX_colourClassName, $anchorColoursLightClassesGeneratorMX_colourHexValue in $colours_anchor_ftColours_light_map {
         .#{$anchorColoursLightClassesGeneratorMX_colourClassName}{            
             a, a:active, a:visited{color: $anchorColoursLightClassesGeneratorMX_colourHexValue;}
-            a:focus, a:hover{color: darken($anchorColoursLightClassesGeneratorMX_colourHexValue, $colours_anchor_ftColours_light_lightenValue);}
+            a:focus, a:hover{color: color.adjust($anchorColoursLightClassesGeneratorMX_colourHexValue, $lightness: -$colours_anchor_ftColours_light_lightenValue);}
         }
     }
 }
@@ -199,7 +201,7 @@
     @each $anchorColoursDarkClassesGeneratorMX_colourClassName, $anchorColoursDarkClassesGeneratorMX_colourHexValue in $colours_anchor_ftColours_dark_map {
         .#{$anchorColoursDarkClassesGeneratorMX_colourClassName}{            
             a, a:active, a:visited{color: $anchorColoursDarkClassesGeneratorMX_colourHexValue;}
-            a:focus, a:hover{color: lighten($anchorColoursDarkClassesGeneratorMX_colourHexValue, $colours_anchor_ftColours_dark_lightenValue);}
+            a:focus, a:hover{color: color.adjust($anchorColoursDarkClassesGeneratorMX_colourHexValue, $lightness: $colours_anchor_ftColours_dark_lightenValue);}
         }
     }
 }

--- a/etc/css/scss/mixins_container.scss
+++ b/etc/css/scss/mixins_container.scss
@@ -2,6 +2,8 @@
    Mixins Container | Etc [/etc/css/scss/mixins_container.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Listado de mixins:
 //

--- a/etc/css/scss/mixins_fonts.scss
+++ b/etc/css/scss/mixins_fonts.scss
@@ -2,6 +2,8 @@
    Fonts Mixins | Etc [/etc/css/scss/mixins_fonts.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_masks.scss
+++ b/etc/css/scss/mixins_masks.scss
@@ -2,6 +2,8 @@
    Mask Mixins | Etc [/etc/css/scss/mixinsMasks.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_opacity.scss
+++ b/etc/css/scss/mixins_opacity.scss
@@ -2,6 +2,8 @@
    Opacity Mixins | Etc [/etc/css/scss/mixinsOpacity.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_positions.scss
+++ b/etc/css/scss/mixins_positions.scss
@@ -2,6 +2,8 @@
    Position Mixins | Etc [/etc/css/scss/mixins_positions.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_sizes.scss
+++ b/etc/css/scss/mixins_sizes.scss
@@ -2,6 +2,8 @@
    Sizes Mixins | Etc [/etc/css/scss/mixinsSizes.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/mixins_spacing.scss
+++ b/etc/css/scss/mixins_spacing.scss
@@ -2,6 +2,8 @@
    Spacing Helpers Mixins | Etc [/etc/css/scss/mixin_spacing.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Mixins para generar nuevos spacing helpers
 

--- a/etc/css/scss/mixins_tables_sizes.scss
+++ b/etc/css/scss/mixins_tables_sizes.scss
@@ -2,6 +2,8 @@
    Tables Sizes Mixins | Etc [/etc/css/scss/mixinsTableSizes.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Generador de clases por cada tamaño de ancho de tabla.
 

--- a/etc/css/scss/mixins_text.scss
+++ b/etc/css/scss/mixins_text.scss
@@ -2,6 +2,8 @@
    Mixins para texto y alturas de X | Etc [/etc/css/scss/mixins_text.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Este archivo contiene mixins para generar declaraciones de tamano en
 // relacion a un valor de altura de X.

--- a/etc/css/scss/mixins_transitions.scss
+++ b/etc/css/scss/mixins_transitions.scss
@@ -2,6 +2,8 @@
    Transition Mixins | Etc [/etc/css/scss/mixinsTransitions.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de mixins.
 

--- a/etc/css/scss/reset_main.scss
+++ b/etc/css/scss/reset_main.scss
@@ -2,6 +2,8 @@
    Elements Reset/Settings | Etc [/etc/css/scss/reset_main.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_container.scss
+++ b/etc/css/scss/settings_container.scss
@@ -2,6 +2,8 @@
    Container Settings | Etc [/etc/css/scss/settings_container.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_form.scss
+++ b/etc/css/scss/settings_form.scss
@@ -2,6 +2,8 @@
    Form Settings | Etc [/etc/css/scss/settings_form.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_html_body.scss
+++ b/etc/css/scss/settings_html_body.scss
@@ -2,6 +2,8 @@
    Html Body Settings | Etc [/etc/css/scss/settings_html_body.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_lightbox.scss
+++ b/etc/css/scss/settings_lightbox.scss
@@ -2,6 +2,8 @@
    Lightbox Settings | Etc [/etc/css/scss/settings_lightbox.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_nav.scss
+++ b/etc/css/scss/settings_nav.scss
@@ -2,6 +2,8 @@
    Nav Settings | Etc [/etc/css/scss/settings_nav.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_nav_accordion.scss
+++ b/etc/css/scss/settings_nav_accordion.scss
@@ -2,6 +2,8 @@
    Nav Accordion Settings | Etc [/etc/css/scss/settings_nav_accordion.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_nav_drawer.scss
+++ b/etc/css/scss/settings_nav_drawer.scss
@@ -2,6 +2,8 @@
    Nav Drawer Settings | Etc [/etc/css/scss/settings_nav_drawer.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_tables.scss
+++ b/etc/css/scss/settings_tables.scss
@@ -2,6 +2,8 @@
    Tables Settings | Etc [/etc/css/scss/settingsTables.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/settings_text.scss
+++ b/etc/css/scss/settings_text.scss
@@ -2,6 +2,8 @@
    Text Settings | Etc [/etc/css/scss/settings_text.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de estilos scss.
 

--- a/etc/css/scss/var_absolute.scss
+++ b/etc/css/scss/var_absolute.scss
@@ -2,6 +2,8 @@
    Absolute Variables | Etc [/etc/css/scss/var_absolute.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/scss/var_container.scss
+++ b/etc/css/scss/var_container.scss
@@ -2,6 +2,8 @@
    Container Variables | Etc [/etc/css/scss/var_container.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.
 

--- a/etc/css/scss/var_fonts.scss
+++ b/etc/css/scss/var_fonts.scss
@@ -2,6 +2,8 @@
    Font Variables | Etc [/etc/css/scss/var_fonts.scss]
    ========================================================================== */
 
+@use "sass:color";
+@use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables.
 // Contiene mapa de fuentes para generar Font-Stacks.
@@ -67,53 +69,53 @@ $font_families_sans_map:(
 );
 
 $font_families_sans_list:
-    map-get($font_families_sans_map, sanFrancisco),
-    map-get($font_families_sans_map, blinkMacSystemFont),
-    map-get($font_families_sans_map, oxygen), 
-    map-get($font_families_sans_map, ubuntu), 
-    map-get($font_families_sans_map, cantarell), 
-    map-get($font_families_sans_map, firaSans), 
-    map-get($font_families_sans_map, droidSans), 
-    map-get($font_families_sans_map, helveticaSafe), 
-    map-get($font_families_sans_map, segoeUI),   
-    map-get($font_families_sans_map, verdana),
-    map-get($font_families_sans_map, tahoma),
-    map-get($font_families_sans_map, lucidaGrande),
-    map-get($font_families_sans_map, trebuchetMS),
-    map-get($font_families_sans_map, sansSerif)
+    map.get($font_families_sans_map, sanFrancisco),
+    map.get($font_families_sans_map, blinkMacSystemFont),
+    map.get($font_families_sans_map, oxygen), 
+    map.get($font_families_sans_map, ubuntu), 
+    map.get($font_families_sans_map, cantarell), 
+    map.get($font_families_sans_map, firaSans), 
+    map.get($font_families_sans_map, droidSans), 
+    map.get($font_families_sans_map, helveticaSafe), 
+    map.get($font_families_sans_map, segoeUI),   
+    map.get($font_families_sans_map, verdana),
+    map.get($font_families_sans_map, tahoma),
+    map.get($font_families_sans_map, lucidaGrande),
+    map.get($font_families_sans_map, trebuchetMS),
+    map.get($font_families_sans_map, sansSerif)
 ; 
 
 $font_families_sans_list_fallback:
     Arial,
     Roboto,
-    map-get($font_families_sans_map, sanFrancisco),
-    map-get($font_families_sans_map, blinkMacSystemFont),
-    map-get($font_families_sans_map, oxygen), 
-    map-get($font_families_sans_map, ubuntu), 
-    map-get($font_families_sans_map, cantarell), 
-    map-get($font_families_sans_map, firaSans), 
-    map-get($font_families_sans_map, droidSans), 
-    map-get($font_families_sans_map, helveticaSafe), 
-    map-get($font_families_sans_map, segoeUI),   
-    map-get($font_families_sans_map, verdana),
-    map-get($font_families_sans_map, tahoma),
-    map-get($font_families_sans_map, lucidaGrande),
-    map-get($font_families_sans_map, trebuchetMS),
-    map-get($font_families_sans_map, sansSerif)
+    map.get($font_families_sans_map, sanFrancisco),
+    map.get($font_families_sans_map, blinkMacSystemFont),
+    map.get($font_families_sans_map, oxygen), 
+    map.get($font_families_sans_map, ubuntu), 
+    map.get($font_families_sans_map, cantarell), 
+    map.get($font_families_sans_map, firaSans), 
+    map.get($font_families_sans_map, droidSans), 
+    map.get($font_families_sans_map, helveticaSafe), 
+    map.get($font_families_sans_map, segoeUI),   
+    map.get($font_families_sans_map, verdana),
+    map.get($font_families_sans_map, tahoma),
+    map.get($font_families_sans_map, lucidaGrande),
+    map.get($font_families_sans_map, trebuchetMS),
+    map.get($font_families_sans_map, sansSerif)
 ; 
 
-$sanFrancisco:          map-get($font_families_sans_map, sanFrancisco);
-$blinkMacSystemFont:    map-get($font_families_sans_map, blinkMacSystemFont);   
-$oxygen:                map-get($font_families_sans_map, oxygen);   
-$ubuntu:                map-get($font_families_sans_map, ubuntu);   
-$cantarell:             map-get($font_families_sans_map, cantarell);   
-$firaSans:              map-get($font_families_sans_map, firaSans);    
-$droidSans:             map-get($font_families_sans_map, droidSans);   
-$segoeUI:               map-get($font_families_sans_map, segoeUI);   
-$verdana:               map-get($font_families_sans_map, verdana);
-$tahoma:                map-get($font_families_sans_map, tahoma);
-$lucidaGrande:          map-get($font_families_sans_map, lucidaGrande);
-$trebuchetMS:           map-get($font_families_sans_map, trebuchetMS);
+$sanFrancisco:          map.get($font_families_sans_map, sanFrancisco);
+$blinkMacSystemFont:    map.get($font_families_sans_map, blinkMacSystemFont);   
+$oxygen:                map.get($font_families_sans_map, oxygen);   
+$ubuntu:                map.get($font_families_sans_map, ubuntu);   
+$cantarell:             map.get($font_families_sans_map, cantarell);   
+$firaSans:              map.get($font_families_sans_map, firaSans);    
+$droidSans:             map.get($font_families_sans_map, droidSans);   
+$segoeUI:               map.get($font_families_sans_map, segoeUI);   
+$verdana:               map.get($font_families_sans_map, verdana);
+$tahoma:                map.get($font_families_sans_map, tahoma);
+$lucidaGrande:          map.get($font_families_sans_map, lucidaGrande);
+$trebuchetMS:           map.get($font_families_sans_map, trebuchetMS);
 
 
 /* // Serif ----------------------------------------------------------------- */
@@ -124,21 +126,21 @@ $font_families_serif_map:(
 );
     
 $font_families_serif_list: 
-    map-get($font_families_serif_map, georgia),
-    map-get($font_families_serif_map, palatino),
-    map-get($font_families_serif_map, serif)
+    map.get($font_families_serif_map, georgia),
+    map.get($font_families_serif_map, palatino),
+    map.get($font_families_serif_map, serif)
 ;
     
 $font_families_serif_list_fallback:
     'Times New Roman',
-    map-get($font_families_serif_map, georgia),
-    map-get($font_families_serif_map, palatino),
-    map-get($font_families_serif_map, serif)
+    map.get($font_families_serif_map, georgia),
+    map.get($font_families_serif_map, palatino),
+    map.get($font_families_serif_map, serif)
 ;
 
-$georgia:   map-get($font_families_serif_map, georgia);
-$palatino:  map-get($font_families_serif_map, palatino);
-$serif:     map-get($font_families_serif_map, serif);
+$georgia:   map.get($font_families_serif_map, georgia);
+$palatino:  map.get($font_families_serif_map, palatino);
+$serif:     map.get($font_families_serif_map, serif);
     
 
 /* // Monoespaciadas -------------------------------------------------------- */
@@ -153,32 +155,32 @@ $font_families_monospaced_map:(
 );
     
 $font_families_monospaced_list:
-    map-get($font_families_monospaced_map, consolas),    
-    map-get($font_families_monospaced_map, andaleMono),
-    map-get($font_families_monospaced_map, lucidaConsole),
-    map-get($font_families_monospaced_map, menlo),
-    map-get($font_families_monospaced_map, bitstreamVeraSansMono),
-    map-get($font_families_monospaced_map, courierNew),
-    map-get($font_families_monospaced_map, monospace)
+    map.get($font_families_monospaced_map, consolas),    
+    map.get($font_families_monospaced_map, andaleMono),
+    map.get($font_families_monospaced_map, lucidaConsole),
+    map.get($font_families_monospaced_map, menlo),
+    map.get($font_families_monospaced_map, bitstreamVeraSansMono),
+    map.get($font_families_monospaced_map, courierNew),
+    map.get($font_families_monospaced_map, monospace)
 ;
     
 $font_families_monospaced_list_fallback:
-    map-get($font_families_monospaced_map, consolas),    
-    map-get($font_families_monospaced_map, andaleMono),
-    map-get($font_families_monospaced_map, lucidaConsole),
-    map-get($font_families_monospaced_map, menlo),
-    map-get($font_families_monospaced_map, bitstreamVeraSansMono),
-    map-get($font_families_monospaced_map, courierNew),
-    map-get($font_families_monospaced_map, monospace)
+    map.get($font_families_monospaced_map, consolas),    
+    map.get($font_families_monospaced_map, andaleMono),
+    map.get($font_families_monospaced_map, lucidaConsole),
+    map.get($font_families_monospaced_map, menlo),
+    map.get($font_families_monospaced_map, bitstreamVeraSansMono),
+    map.get($font_families_monospaced_map, courierNew),
+    map.get($font_families_monospaced_map, monospace)
 ;
 
-$consolas:                  map-get($font_families_monospaced_map, consolas);
-$andaleMono:                map-get($font_families_monospaced_map, andaleMono);
-$lucidaConsole:             map-get($font_families_monospaced_map, lucidaConsole);
-$menlo:                     map-get($font_families_monospaced_map, menlo);
-$bitstreamVeraSansMono:     map-get($font_families_monospaced_map, bitstreamVeraSansMono);
-$courierNew:                map-get($font_families_monospaced_map, courierNew);
-$monospace:                 map-get($font_families_monospaced_map, monospace);
+$consolas:                  map.get($font_families_monospaced_map, consolas);
+$andaleMono:                map.get($font_families_monospaced_map, andaleMono);
+$lucidaConsole:             map.get($font_families_monospaced_map, lucidaConsole);
+$menlo:                     map.get($font_families_monospaced_map, menlo);
+$bitstreamVeraSansMono:     map.get($font_families_monospaced_map, bitstreamVeraSansMono);
+$courierNew:                map.get($font_families_monospaced_map, courierNew);
+$monospace:                 map.get($font_families_monospaced_map, monospace);
 
 /* // Font Sizes ------------------------------------------------------------ */
 $h1_list: 'h1, .heading1';

--- a/etc/resources/accordion/accordion.scss
+++ b/etc/resources/accordion/accordion.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+@use "sass:map";
 .list_accordion{
     max-width: 700px;
     margin-right: auto;

--- a/etc/resources/parallax/css/parallax.scss
+++ b/etc/resources/parallax/css/parallax.scss
@@ -1,6 +1,8 @@
 /* =============================================================================
    Parallax Scroll
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 html,body{height:100%;min-height:100%;position:relative}
 #header.parallaxHeader{
     position:fixed;

--- a/etc/resources/parallax/css/parallax_scroll.scss
+++ b/etc/resources/parallax/css/parallax_scroll.scss
@@ -1,6 +1,8 @@
 /* =============================================================================
    Parallax Scroll
    ========================================================================== */
+@use "sass:color";
+@use "sass:map";
 html,body{
     overflow:hidden;
 /*    height:100%;min-height:100%;position:relative;*/


### PR DESCRIPTION
## Summary
- ensure every Sass source pulls in the sass:color and sass:map modules once
- replace legacy map-merge/map-get calls with map.merge/map.get helpers
- migrate darken/lighten usages to color.adjust for Dart Sass compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa374fc5bc83278b035ca4c6e22b1d