### PR TITLE
Add Dart Sass module imports to custom SCSS

### DIFF
--- a/etc/css/custom/__fontFace_zh.scss
+++ b/etc/css/custom/__fontFace_zh.scss
@@ -2,6 +2,9 @@
    Font-face | Custom [/etc/css/custom/fontFace_zh.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/__styles_zh.scss
+++ b/etc/css/custom/__styles_zh.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    CSS Styles Main | Custom [/etc/css/custom/styles_zh.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @import "../scss/charset";

--- a/etc/css/custom/_animation.scss
+++ b/etc/css/custom/_animation.scss
@@ -2,6 +2,9 @@
    Animations | Custom [/etc/css/custom/animation.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_body.scss
+++ b/etc/css/custom/_body.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Body Styles | Custom [/etc/css/custom/body.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 body{

--- a/etc/css/custom/_breadcrumbs.scss
+++ b/etc/css/custom/_breadcrumbs.scss
@@ -2,6 +2,9 @@
    Breadcrumb Styles | Custom [/etc/css/custom/breadcrumbs.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_buttons.scss
+++ b/etc/css/custom/_buttons.scss
@@ -2,6 +2,9 @@
    Button Styles | Custom [/etc/css/custom/buttons.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_classes_backgrounds.scss
+++ b/etc/css/custom/_classes_backgrounds.scss
@@ -2,6 +2,9 @@
    Backgrounds Classes | Custom [/etc/css/custom/classes_backgrounds.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_classes_text.scss
+++ b/etc/css/custom/_classes_text.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Text Classes | Custom [/etc/css/custom/classes_text.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .txBold{    

--- a/etc/css/custom/_colours_gradients.scss
+++ b/etc/css/custom/_colours_gradients.scss
@@ -2,6 +2,9 @@
    Gradient Colours | Custom [/etc/css/custom/colours_gradients.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 // Colour colourPercent 00%

--- a/etc/css/custom/_focus.scss
+++ b/etc/css/custom/_focus.scss
@@ -2,6 +2,9 @@
    Focus Styles | Custom [/etc/css/custom/focus.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_fontFace.scss
+++ b/etc/css/custom/_fontFace.scss
@@ -2,6 +2,9 @@
    Font-face | Custom [/etc/css/custom/fontFace.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_footer.scss
+++ b/etc/css/custom/_footer.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Footer Styles | Custom [/etc/css/custom/footer.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @import 'imp/footer_fullHeight_imp';

--- a/etc/css/custom/_form.scss
+++ b/etc/css/custom/_form.scss
@@ -2,6 +2,9 @@
    Form Styles | Custom [/etc/css/custom/form.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Form Fieldset --------------------------------------------------------- */

--- a/etc/css/custom/_form_checkbox.scss
+++ b/etc/css/custom/_form_checkbox.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Form Checkbox Accesible Styles | Custom [/etc/css/custom/form_checkbox.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @supports(-webkit-appearance: none) {

--- a/etc/css/custom/_form_search.scss
+++ b/etc/css/custom/_form_search.scss
@@ -2,6 +2,9 @@
    Search Form Styles | Custom [/etc/css/custom/form_search.scss]
    ========================================================================== */
 //form.searchForm
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .searchForm{

--- a/etc/css/custom/_global.scss
+++ b/etc/css/custom/_global.scss
@@ -2,6 +2,9 @@
    Global Styles | Custom [/etc/css/custom/global.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_header.scss
+++ b/etc/css/custom/_header.scss
@@ -2,6 +2,9 @@
    Header Styles | Custom [/etc/css/custom/header.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 // REF [15] Nav Fixed AT

--- a/etc/css/custom/_hover.scss
+++ b/etc/css/custom/_hover.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Hover Classes | Custom [/etc/css/custom/hover.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @include afterMQ768{

--- a/etc/css/custom/_iframe.scss
+++ b/etc/css/custom/_iframe.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    iframe Styles | Custom [/etc/css/custom/iframe.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .iframe_video_mask,

--- a/etc/css/custom/_includes_backgrounds.scss
+++ b/etc/css/custom/_includes_backgrounds.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Backgrounds Includes | Custom [/etc/css/custom/includes_backgrounds.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @include backgroundColourClassesGenerator;

--- a/etc/css/custom/_lightbox.scss
+++ b/etc/css/custom/_lightbox.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Lightbox Styles | Custom [/etc/css/custom/lightbox.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .lightboxOverlay{

--- a/etc/css/custom/_lists.scss
+++ b/etc/css/custom/_lists.scss
@@ -2,6 +2,9 @@
    Lists | Custom [/etc/css/custom/lists.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_mediaQueries_mx.scss
+++ b/etc/css/custom/_mediaQueries_mx.scss
@@ -2,6 +2,8 @@
    Media Queries Mixins | Custom [/etc/css/custom/mediaQueries_mx.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_mediaQueries_placeholders.scss
+++ b/etc/css/custom/_mediaQueries_placeholders.scss
@@ -2,6 +2,9 @@
    Media Queries Placeholders | Custom [/etc/css/custom/mediaQueries_placeholders.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
     @include beforeMQ300{}

--- a/etc/css/custom/_nav_lang.scss
+++ b/etc/css/custom/_nav_lang.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Language Switch Styles | Custom [/etc/css/custom/nav_lang.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .nav_lang_ul{

--- a/etc/css/custom/_nav_lang_square.scss
+++ b/etc/css/custom/_nav_lang_square.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Language Switch Styles | Custom [/etc/css/custom/nav_lang.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .nav_lang_ul{

--- a/etc/css/custom/_nav_main_ALL.scss
+++ b/etc/css/custom/_nav_main_ALL.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main ALL Styles | Custom [/etc/css/custom/nav_main_ALL.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .nav_main_ul{

--- a/etc/css/custom/_nav_main_AT.scss
+++ b/etc/css/custom/_nav_main_AT.scss
@@ -2,6 +2,9 @@
    Nav Main After Tablet Styles | Custom [/etc/css/custom/nav_main_AT.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 // REF [05] Container para doble nav

--- a/etc/css/custom/_nav_main_accordion.scss
+++ b/etc/css/custom/_nav_main_accordion.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main Accordion Styles | Custom [/etc/css/custom/nav_main_accordion.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @if $nav_accordion_act == "on"{

--- a/etc/css/custom/_nav_main_drawer.scss
+++ b/etc/css/custom/_nav_main_drawer.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main Drawer BT Styles | Custom [/etc/css/custom/nav_main_drawer.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @if $nav_drawer_act == "on"{

--- a/etc/css/custom/_nav_main_list.scss
+++ b/etc/css/custom/_nav_main_list.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main List Styles | Custom [/etc/css/custom/nav_main_list.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @if $nav_list_act == "on"{

--- a/etc/css/custom/_page_construccion.scss
+++ b/etc/css/custom/_page_construccion.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Page Construccion Styles | Custom [/etc/css/custom/page_construccion.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .page_construccion{

--- a/etc/css/custom/_page_contacto.scss
+++ b/etc/css/custom/_page_contacto.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Page Contacto Styles | Custom [/etc/css/custom/page_contacto.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .page_contacto{}

--- a/etc/css/custom/_page_copyright.scss
+++ b/etc/css/custom/_page_copyright.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Page Copyright Styles | Custom [/etc/css/custom/page_copyright.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .page_copyright{

--- a/etc/css/custom/_page_error.scss
+++ b/etc/css/custom/_page_error.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Page Error Styles | Custom [/etc/css/custom/page_error.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .page_error{

--- a/etc/css/custom/_page_gracias.scss
+++ b/etc/css/custom/_page_gracias.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Page Gracias Styles | Custom [/etc/css/custom/page_gracias.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .page_gracias{

--- a/etc/css/custom/_page_index.scss
+++ b/etc/css/custom/_page_index.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Page Index Styles | Custom [/etc/css/custom/page_index.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @import 'imp/page_index_fullHeight_imp';

--- a/etc/css/custom/_popup.scss
+++ b/etc/css/custom/_popup.scss
@@ -2,6 +2,9 @@
    Popup Styles | Custom [/etc/css/custom/popup.scss]
    ========================================================================== */
     
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Pop Modal ------------------------------------------------------------- */

--- a/etc/css/custom/_print.scss
+++ b/etc/css/custom/_print.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Print Styles | Custom [/etc/css/custom/print.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 @media print {

--- a/etc/css/custom/_reset_custom.scss
+++ b/etc/css/custom/_reset_custom.scss
@@ -1,5 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Custom Reset Styles | Custom [/etc/css/custom/reset_custom.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";

--- a/etc/css/custom/_scrollbar.scss
+++ b/etc/css/custom/_scrollbar.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Scrollbar Styles | Custom [/etc/css/custom/scrollbar.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .scrollbar::-webkit-scrollbar{

--- a/etc/css/custom/_shadows.scss
+++ b/etc/css/custom/_shadows.scss
@@ -2,6 +2,9 @@
    Shadows Classes | Custom [/etc/css/custom/shadows.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_slider.scss
+++ b/etc/css/custom/_slider.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Slider Styles | Custom [/etc/css/custom/slider.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .slick,

--- a/etc/css/custom/_slider_nav.scss
+++ b/etc/css/custom/_slider_nav.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Slider Nav Styles | Custom [/etc/css/custom/slider_nav.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .slick_nav{

--- a/etc/css/custom/_social.scss
+++ b/etc/css/custom/_social.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Social Styles | Custom [/etc/css/custom/social.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 .social{

--- a/etc/css/custom/_tables.scss
+++ b/etc/css/custom/_tables.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    Tables Styles | Custom [/etc/css/custom/tables.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 table{

--- a/etc/css/custom/_text.scss
+++ b/etc/css/custom/_text.scss
@@ -2,6 +2,9 @@
    Settings Text | Custom [/etc/css/custom/text.scss]
    ========================================================================== */
 
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/_wp_styles.scss
+++ b/etc/css/custom/_wp_styles.scss
@@ -1,6 +1,9 @@
 /* * NombreDeProyecto * ========================================================
    WordPress Styles | Custom [/etc/css/custom/wp_styles.scss]
    ========================================================================== */
+@use "var/env_var" as *;
+@use "../scss/var_all" as *;
+
 @use "sass:color";
 @use "sass:map";
 


### PR DESCRIPTION
## Summary
- add the shared `@use "var/env_var"` header to each custom SCSS partial and include `@use "../scss/var_all"` where required for Dart Sass compatibility
- respect the exception for `_mediaQueries_mx.scss` by only importing the environment variables module there

## Testing
- not run (scss-only change)

------
https://chatgpt.com/codex/tasks/task_e_68fa4bdfb9f883278376172a5d97b07e