### PR TITLE
Refactor SCSS imports for Dart Sass modules

### DIFF
--- a/etc/css/custom/_buttons.scss
+++ b/etc/css/custom/_buttons.scss
@@ -2,6 +2,8 @@
    Button Styles | Custom [/etc/css/custom/buttons.scss]
    ========================================================================== */
 
+@use "act/buttons_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/_footer.scss
+++ b/etc/css/custom/_footer.scss
@@ -6,7 +6,7 @@
 
 @use "sass:color";
 @use "sass:map";
-@import 'imp/footer_fullHeight_imp';
+//@import 'imp/footer_fullHeight_imp';
 
 #footer{
     background-color: $footer_bgColour;

--- a/etc/css/custom/_global.scss
+++ b/etc/css/custom/_global.scss
@@ -2,6 +2,8 @@
    Global Styles | Custom [/etc/css/custom/global.scss]
    ========================================================================== */
 
+@use "var/text_var" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 
@@ -50,8 +52,8 @@
 
 
 /* // Main Gobal Styles ----------------------------------------------------- */
-@import 'imp/page_section_fullHeight_imp';
-@import 'imp/page_headerFixed_imp';
+//@import 'imp/page_section_fullHeight_imp';
+//@import 'imp/page_headerFixed_imp';
 
 #dev_window_width{
     /* // REF [48] Dev window width */

--- a/etc/css/custom/_header.scss
+++ b/etc/css/custom/_header.scss
@@ -9,8 +9,8 @@
 @use "sass:map";
 // REF [15] Nav Fixed AT
 
-@import 'imp/header_fullHeight_imp';
-@import 'imp/header_headerFixed_imp';
+//@import 'imp/header_fullHeight_imp';
+//@import 'imp/header_headerFixed_imp';
 
 #header{
     box-sizing: border-box;

--- a/etc/css/custom/_mediaQueries_mx.scss
+++ b/etc/css/custom/_mediaQueries_mx.scss
@@ -2,6 +2,8 @@
    Media Queries Mixins | Custom [/etc/css/custom/mediaQueries_mx.scss]
    ========================================================================== */
 
+@use "var/mediaQueries_var" as *;
+
 @use "var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/custom/_nav_main_ALL.scss
+++ b/etc/css/custom/_nav_main_ALL.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main ALL Styles | Custom [/etc/css/custom/nav_main_ALL.scss]
    ========================================================================== */
+@use "act/nav_main_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/_nav_main_AT.scss
+++ b/etc/css/custom/_nav_main_AT.scss
@@ -2,6 +2,8 @@
    Nav Main After Tablet Styles | Custom [/etc/css/custom/nav_main_AT.scss]
    ========================================================================== */
 
+@use "act/nav_main_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/_nav_main_accordion.scss
+++ b/etc/css/custom/_nav_main_accordion.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main Accordion Styles | Custom [/etc/css/custom/nav_main_accordion.scss]
    ========================================================================== */
+@use "act/nav_main_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/_nav_main_drawer.scss
+++ b/etc/css/custom/_nav_main_drawer.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main Drawer BT Styles | Custom [/etc/css/custom/nav_main_drawer.scss]
    ========================================================================== */
+@use "act/nav_main_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/_nav_main_list.scss
+++ b/etc/css/custom/_nav_main_list.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Nav Main List Styles | Custom [/etc/css/custom/nav_main_list.scss]
    ========================================================================== */
+@use "act/nav_main_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/_page_index.scss
+++ b/etc/css/custom/_page_index.scss
@@ -6,7 +6,7 @@
 
 @use "sass:color";
 @use "sass:map";
-@import 'imp/page_index_fullHeight_imp';
+//@import 'imp/page_index_fullHeight_imp';
 
 .page_index{
     &.page_index_index{}

--- a/etc/css/custom/_slider.scss
+++ b/etc/css/custom/_slider.scss
@@ -1,6 +1,8 @@
 /* * NombreDeProyecto * ========================================================
    Slider Styles | Custom [/etc/css/custom/slider.scss]
    ========================================================================== */
+@use "act/slider_act" as *;
+
 @use "var/env_var" as *;
 @use "../scss/var_all" as *;
 

--- a/etc/css/custom/styles_zh.scss
+++ b/etc/css/custom/styles_zh.scss
@@ -4,44 +4,44 @@
 @use "sass:color";
 @use "sass:map";
 
-@import "../scss/charset";
-@import "var/env_var";
+//@import "../scss/charset";
+//@import "var/env_var";
 
-@import "../scss/var_fonts";
-@import "var/fonts_main_zh_var";
-@import "var/text_zh_var";
-@import "fontFace_zh";
+//@import "../scss/var_fonts";
+//@import "var/fonts_main_zh_var";
+//@import "var/text_zh_var";
+//@import "fontFace_zh";
 
 @use "../scss/var_all_pre" as *;
 
 /* // Main CSS -------------------------------------------------------------- */
-@import "../scss/settings_html_body";
-@import "body";
-@import "../scss/reset_main";
-@import "reset_custom";
+//@import "../scss/settings_html_body";
+//@import "body";
+//@import "../scss/reset_main";
+//@import "reset_custom";
 
-@import "colours_gradients";
+//@import "colours_gradients";
 
-@import "../scss/settings_text";
-@import "text";
-@import "classes_text"; 
+//@import "../scss/settings_text";
+//@import "text";
+//@import "classes_text"; 
 
-@import "includes_backgrounds";
-@import "classes_backgrounds";
-@import "shadows";
+//@import "includes_backgrounds";
+//@import "classes_backgrounds";
+//@import "shadows";
 
-@import "../scss/classes_useful_all";
-@import "../scss/classes_useful_responsive";
+//@import "../scss/classes_useful_all";
+//@import "../scss/classes_useful_responsive";
 
-@import "../scss/settings_container";
+//@import "../scss/settings_container";
 
 //@use "print";
 
-@import "global";
-@import "lists";
-@import "buttons";
-@import "hover";
-@import "focus";
+//@import "global";
+//@import "lists";
+//@import "buttons";
+//@import "hover";
+//@import "focus";
 //@use "scrollbar";
 //@use "breadcrumbs";
 //@use "iframe";
@@ -49,28 +49,28 @@
 //@use "animation";
 //@use "animation_index";
 
-@import "../scss/settings_form";
-@import "form";
+//@import "../scss/settings_form";
+//@import "form";
 //@use "form_search";
 //@use "form_checkbox";
 
 //@use "../scss/settings_tables";
 //@use "tables";
 
-@import "popup";
+//@import "popup";
 
-@import "header";
+//@import "header";
 //@use "social";
-@import "footer";
+//@import "footer";
 
-@import "../scss/settings_nav";
-@import "../scss/settings_nav_drawer";
-@import "../scss/settings_nav_accordion";
-@import "nav_main_drawer";
-@import "nav_main_accordion";
-@import "nav_main_list";
-@import "nav_main_AT";
-@import "nav_main_ALL";
+//@import "../scss/settings_nav";
+//@import "../scss/settings_nav_drawer";
+//@import "../scss/settings_nav_accordion";
+//@import "nav_main_drawer";
+//@import "nav_main_accordion";
+//@import "nav_main_list";
+//@import "nav_main_AT";
+//@import "nav_main_ALL";
 //@use "nav_lang";
 //@use "nav_lang_square";
 

--- a/etc/css/custom/var/_button_nav_hamburger_var.scss
+++ b/etc/css/custom/var/_button_nav_hamburger_var.scss
@@ -2,6 +2,11 @@
    Button Nav Hamburger Variables | Custom [/etc/css/custom/var/button_nav_hamburger_var.scss]
    ========================================================================== */
 
+@use  "fonts_main_var" as *;
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_buttons_var.scss
+++ b/etc/css/custom/var/_buttons_var.scss
@@ -2,6 +2,11 @@
    Buttons Variables | Custom [/etc/css/custom/var/buttons_var.scss]
    ========================================================================== */
 
+@use  "fonts_main_var" as *;
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_colours_backgrounds_var.scss
+++ b/etc/css/custom/var/_colours_backgrounds_var.scss
@@ -2,6 +2,8 @@
    Background Colours Variables | Custom [/etc/css/custom/var/colours_backgrounds_var.scss]
    ========================================================================== */
 
+@use  "colours_main_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_colours_borders_var.scss
+++ b/etc/css/custom/var/_colours_borders_var.scss
@@ -2,6 +2,8 @@
    Border Colours Variables | Custom [/etc/css/custom/var/colours_borders_var.scss]
    ========================================================================== */
 
+@use  "colours_main_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_fonts_main_var.scss
+++ b/etc/css/custom/var/_fonts_main_var.scss
@@ -2,6 +2,8 @@
    Fonts Main Variables | Custom [/etc/css/custom/var/fonts_main_var.scss]
    ========================================================================== */
 
+@use "../../scss/var_fonts" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_footer_var.scss
+++ b/etc/css/custom/var/_footer_var.scss
@@ -2,6 +2,11 @@
    Footer Variables | Custom [/etc/css/custom/var/footer_var.scss]
    ========================================================================== */
 
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+@use "social_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Full heights Footer --------------------------------------------------- */

--- a/etc/css/custom/var/_form_colours_var.scss
+++ b/etc/css/custom/var/_form_colours_var.scss
@@ -2,6 +2,13 @@
    Form Colours Variables | Custom [/etc/css/custom/var/form_colours_var.scss]
    ========================================================================== */
 
+@use  "buttons_var" as *;
+@use  "text_var" as *;
+@use  "fonts_main_var" as *;
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_form_fonts_var.scss
+++ b/etc/css/custom/var/_form_fonts_var.scss
@@ -2,6 +2,9 @@
    Form Fonts Variables | Custom [/etc/css/custom/var/form_fonts_var.scss]
    ========================================================================== */
 
+@use  "text_var" as *;
+@use  "fonts_main_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Referencias globales de nombres de variables y mixins ----------------- */

--- a/etc/css/custom/var/_form_sizes_var.scss
+++ b/etc/css/custom/var/_form_sizes_var.scss
@@ -2,6 +2,9 @@
    Form Sizes Variables | Custom [/etc/css/custom/var/form_sizes_var.scss]
    ========================================================================== */
 
+@use  "text_var" as *;
+@use "../scss/var_absolute" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_header_var.scss
+++ b/etc/css/custom/var/_header_var.scss
@@ -2,6 +2,8 @@
    Header Variables | Custom [/etc/css/custom/var/header_var.scss]
    ========================================================================== */
 
+@use  "logo_sizes_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_helpers_var.scss
+++ b/etc/css/custom/var/_helpers_var.scss
@@ -2,6 +2,8 @@
    Spacing Helpers Variables | Custom [/etc/css/custom/var/helpers.scss]
    ========================================================================== */
 
+@use "../scss/var_absolute" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Spacing --------------------------------------------------------------- */

--- a/etc/css/custom/var/_logo_sizes_var.scss
+++ b/etc/css/custom/var/_logo_sizes_var.scss
@@ -2,6 +2,9 @@
    Logo Sizes Variables | Custom [/etc/css/custom/var/logo_sizes_var.scss]
    ========================================================================== */
 
+@use "button_nav_hamburger_var" as *;
+@use "nav_sizes_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_nav_colours_var.scss
+++ b/etc/css/custom/var/_nav_colours_var.scss
@@ -2,6 +2,10 @@
    Nav Colours Variables | Custom [/etc/css/custom/var/nav_colours_var.scss]
    ========================================================================== */
 
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_nav_fonts_var.scss
+++ b/etc/css/custom/var/_nav_fonts_var.scss
@@ -2,6 +2,8 @@
    Nav Fonts Variables | Custom [/etc/css/custom/var/nav_fonts_var.scss]
    ========================================================================== */
 
+@use "fonts_main_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_nav_lang_var.scss
+++ b/etc/css/custom/var/_nav_lang_var.scss
@@ -2,6 +2,10 @@
    Nav Language Variables | Custom [/etc/css/custom/var/nav_lang_var.scss]
    ========================================================================== */
 
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_nav_sizes_var.scss
+++ b/etc/css/custom/var/_nav_sizes_var.scss
@@ -2,6 +2,9 @@
    Nav Sizes Variables | Custom [/etc/css/custom/var/nav_sizes_var.scss]
    ========================================================================== */
 
+@use  "helpers_var" as *;
+@use "button_nav_hamburger_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_popup_var.scss
+++ b/etc/css/custom/var/_popup_var.scss
@@ -2,6 +2,10 @@
    Popup Variables | Custom [/etc/css/custom/var/popup_var.scss]
    ========================================================================== */
 
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_shadows_var.scss
+++ b/etc/css/custom/var/_shadows_var.scss
@@ -2,6 +2,11 @@
    Shadows Variables | Custom [/etc/css/custom/var/shadows_var.scss]
    ========================================================================== */
 
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+@use "env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_slider_var.scss
+++ b/etc/css/custom/var/_slider_var.scss
@@ -2,6 +2,11 @@
    Slider Variables | Custom [/etc/css/custom/var/slider_var.scss]
    ========================================================================== */
 
+@use "../scss/var_absolute" as *;
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_tables_colours_var.scss
+++ b/etc/css/custom/var/_tables_colours_var.scss
@@ -2,6 +2,10 @@
    Tables Colours Variables | Custom [/etc/css/custom/var/tables_colours_var.scss]
    ========================================================================== */
 
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Table Border Colours -------------------------------------------------- */

--- a/etc/css/custom/var/_tables_var.scss
+++ b/etc/css/custom/var/_tables_var.scss
@@ -2,6 +2,9 @@
    Tables Variables | Custom [/etc/css/custom/var/tables.scss]
    ========================================================================== */
 
+@use "../scss/var_absolute" as *;
+@use  "helpers_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/custom/var/_text_var.scss
+++ b/etc/css/custom/var/_text_var.scss
@@ -2,6 +2,12 @@
    Text Variables | Custom [/etc/css/custom/var/text_var.scss]
    ========================================================================== */
 
+@use "../../scss/var_fonts" as *;
+@use  "fonts_main_var" as *;
+@use "colours_main_var" as *;
+@use "colours_borders_var" as *;
+@use "colours_backgrounds_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/charset.scss
+++ b/etc/css/scss/charset.scss
@@ -1,3 +1,5 @@
+@use "../custom/var/env_var" as *;
+
 @charset "UTF-8";
 @use "sass:color";
 @use "sass:map";

--- a/etc/css/scss/classes_useful_all.scss
+++ b/etc/css/scss/classes_useful_all.scss
@@ -2,6 +2,8 @@
    Useful Classes ALL | Etc [/etc/css/scss/classes_useful_all.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/classes_useful_responsive.scss
+++ b/etc/css/scss/classes_useful_responsive.scss
@@ -2,6 +2,8 @@
    Useful Classes Responsive | Etc [/etc/css/scss/classes_useful_responsive.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/functions_angledEdges.scss
+++ b/etc/css/scss/functions_angledEdges.scss
@@ -2,6 +2,8 @@
    Angled Edges Functions | Etc [/etc/css/scss/functions_angledEdges.scss]scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 //-------------------------------------------------------------------------------------

--- a/etc/css/scss/functions_fontStroke.scss
+++ b/etc/css/scss/functions_fontStroke.scss
@@ -2,6 +2,8 @@
    Font Stroke Functions | Etc [/etc/css/scss/functionsFontStroke.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_backgrounds.scss
+++ b/etc/css/scss/mixins_backgrounds.scss
@@ -2,6 +2,8 @@
    Background Mixins | Etc [/etc/css/scss/mixins_backgrounds.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_borders.scss
+++ b/etc/css/scss/mixins_borders.scss
@@ -2,6 +2,9 @@
    Border Helpers Mixins | Etc [/etc/css/scss/mixins_borders.scss]
    ========================================================================== */
 
+@use "../custom/var/helpers_var" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_center.scss
+++ b/etc/css/scss/mixins_center.scss
@@ -2,6 +2,9 @@
    Center Mixins | Etc [/etc/css/scss/mixins_center.scss]
    ========================================================================== */
 
+@use "var_absolute" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_clearfix.scss
+++ b/etc/css/scss/mixins_clearfix.scss
@@ -2,6 +2,8 @@
    Mixin  Clearfix | Etc [/etc/css/scss/mixins_clearfix.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_clipPath.scss
+++ b/etc/css/scss/mixins_clipPath.scss
@@ -2,6 +2,8 @@
    Clip Paths Mixins | Etc [/etc/css/scss/mixinsClipPath.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_colours.scss
+++ b/etc/css/scss/mixins_colours.scss
@@ -2,6 +2,13 @@
    Colour Mixins | Etc [/etc/css/scss/mixins_colours.scss]
    ========================================================================== */
 
+@use "../custom/act/buttons_act" as *;
+@use "../custom/act/form_act" as *;
+@use "../custom/var/colours_main_var" as *;
+@use "../custom/var/colours_borders_var" as *;
+@use "../custom/var/colours_backgrounds_var" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_container.scss
+++ b/etc/css/scss/mixins_container.scss
@@ -2,6 +2,9 @@
    Mixins Container | Etc [/etc/css/scss/mixins_container.scss]
    ========================================================================== */
 
+@use "../custom/var/container_sizes_var" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_fonts.scss
+++ b/etc/css/scss/mixins_fonts.scss
@@ -2,6 +2,10 @@
    Fonts Mixins | Etc [/etc/css/scss/mixins_fonts.scss]
    ========================================================================== */
 
+@use "../custom/var/text_var" as *;
+@use "../custom/var/fonts_main_var" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_masks.scss
+++ b/etc/css/scss/mixins_masks.scss
@@ -2,6 +2,8 @@
    Mask Mixins | Etc [/etc/css/scss/mixinsMasks.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_opacity.scss
+++ b/etc/css/scss/mixins_opacity.scss
@@ -2,6 +2,8 @@
    Opacity Mixins | Etc [/etc/css/scss/mixinsOpacity.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_positions.scss
+++ b/etc/css/scss/mixins_positions.scss
@@ -2,6 +2,8 @@
    Position Mixins | Etc [/etc/css/scss/mixins_positions.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_sizes.scss
+++ b/etc/css/scss/mixins_sizes.scss
@@ -2,6 +2,8 @@
    Sizes Mixins | Etc [/etc/css/scss/mixinsSizes.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_spacing.scss
+++ b/etc/css/scss/mixins_spacing.scss
@@ -2,6 +2,9 @@
    Spacing Helpers Mixins | Etc [/etc/css/scss/mixin_spacing.scss]
    ========================================================================== */
 
+@use "../custom/var/helpers_var" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_tables_sizes.scss
+++ b/etc/css/scss/mixins_tables_sizes.scss
@@ -2,6 +2,8 @@
    Tables Sizes Mixins | Etc [/etc/css/scss/mixinsTableSizes.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_text.scss
+++ b/etc/css/scss/mixins_text.scss
@@ -2,6 +2,8 @@
    Mixins para texto y alturas de X | Etc [/etc/css/scss/mixins_text.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/mixins_transitions.scss
+++ b/etc/css/scss/mixins_transitions.scss
@@ -2,6 +2,8 @@
    Transition Mixins | Etc [/etc/css/scss/mixinsTransitions.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/reset_main.scss
+++ b/etc/css/scss/reset_main.scss
@@ -2,6 +2,8 @@
    Elements Reset/Settings | Etc [/etc/css/scss/reset_main.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_container.scss
+++ b/etc/css/scss/settings_container.scss
@@ -2,6 +2,8 @@
    Container Settings | Etc [/etc/css/scss/settings_container.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_form.scss
+++ b/etc/css/scss/settings_form.scss
@@ -2,6 +2,8 @@
    Form Settings | Etc [/etc/css/scss/settings_form.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_html_body.scss
+++ b/etc/css/scss/settings_html_body.scss
@@ -2,6 +2,8 @@
    Html Body Settings | Etc [/etc/css/scss/settings_html_body.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_lightbox.scss
+++ b/etc/css/scss/settings_lightbox.scss
@@ -2,6 +2,8 @@
    Lightbox Settings | Etc [/etc/css/scss/settings_lightbox.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_nav.scss
+++ b/etc/css/scss/settings_nav.scss
@@ -2,6 +2,8 @@
    Nav Settings | Etc [/etc/css/scss/settings_nav.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_nav_accordion.scss
+++ b/etc/css/scss/settings_nav_accordion.scss
@@ -2,6 +2,8 @@
    Nav Accordion Settings | Etc [/etc/css/scss/settings_nav_accordion.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_nav_drawer.scss
+++ b/etc/css/scss/settings_nav_drawer.scss
@@ -2,6 +2,9 @@
    Nav Drawer Settings | Etc [/etc/css/scss/settings_nav_drawer.scss]
    ========================================================================== */
 
+@use "../custom/act/nav_main_act" as *;
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_tables.scss
+++ b/etc/css/scss/settings_tables.scss
@@ -2,6 +2,8 @@
    Tables Settings | Etc [/etc/css/scss/settingsTables.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/settings_text.scss
+++ b/etc/css/scss/settings_text.scss
@@ -2,6 +2,8 @@
    Text Settings | Etc [/etc/css/scss/settings_text.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/var_absolute.scss
+++ b/etc/css/scss/var_absolute.scss
@@ -2,6 +2,8 @@
    Absolute Variables | Etc [/etc/css/scss/var_absolute.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */

--- a/etc/css/scss/var_all_post.scss
+++ b/etc/css/scss/var_all_post.scss
@@ -2,6 +2,8 @@
    CSS Styles Post | Custom [/etc/css/custom/var_all_post.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Post ------------------------------------------------------------------ */

--- a/etc/css/scss/var_all_pre.scss
+++ b/etc/css/scss/var_all_pre.scss
@@ -2,6 +2,8 @@
    CSS Styles Pre | Custom [/etc/css/custom/var_all_pre.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de asignacion de variables.
 

--- a/etc/css/scss/var_container.scss
+++ b/etc/css/scss/var_container.scss
@@ -3,6 +3,8 @@
    ========================================================================== */
 
 @use "sass:color";
+@use "../custom/var/container_sizes_var" as *;
+
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */
 // Archivo de variables scss.

--- a/etc/css/scss/var_fonts.scss
+++ b/etc/css/scss/var_fonts.scss
@@ -2,6 +2,8 @@
    Font Variables | Etc [/etc/css/scss/var_fonts.scss]
    ========================================================================== */
 
+@use "../custom/var/env_var" as *;
+
 @use "sass:color";
 @use "sass:map";
 /* // Descripcion ----------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- comment out legacy `@import` directives across SCSS files in preparation for Dart Sass modules
- add the required `@use` statements to custom components and variable partials
- import the shared `env_var` module across `etc/css/scss` and update `var_container.scss` dependencies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa541e25c0832790b1e902de394b57