### PR TITLE
Add var_all use statements to SCSS files

### DIFF
--- a/etc/css/scss/classes_useful_all.scss
+++ b/etc/css/scss/classes_useful_all.scss
@@ -2,6 +2,7 @@
    Useful Classes ALL | Etc [/etc/css/scss/classes_useful_all.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/classes_useful_responsive.scss
+++ b/etc/css/scss/classes_useful_responsive.scss
@@ -2,6 +2,7 @@
    Useful Classes Responsive | Etc [/etc/css/scss/classes_useful_responsive.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/mixins_clearfix.scss
+++ b/etc/css/scss/mixins_clearfix.scss
@@ -2,6 +2,7 @@
    Mixin  Clearfix | Etc [/etc/css/scss/mixins_clearfix.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/mixins_container.scss
+++ b/etc/css/scss/mixins_container.scss
@@ -2,6 +2,7 @@
    Mixins Container | Etc [/etc/css/scss/mixins_container.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/container_sizes_var" as *;
 @use "../custom/var/env_var" as *;
 

--- a/etc/css/scss/reset_main.scss
+++ b/etc/css/scss/reset_main.scss
@@ -2,6 +2,7 @@
    Elements Reset/Settings | Etc [/etc/css/scss/reset_main.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_container.scss
+++ b/etc/css/scss/settings_container.scss
@@ -2,6 +2,7 @@
    Container Settings | Etc [/etc/css/scss/settings_container.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_form.scss
+++ b/etc/css/scss/settings_form.scss
@@ -2,6 +2,7 @@
    Form Settings | Etc [/etc/css/scss/settings_form.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_html_body.scss
+++ b/etc/css/scss/settings_html_body.scss
@@ -2,6 +2,7 @@
    Html Body Settings | Etc [/etc/css/scss/settings_html_body.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_lightbox.scss
+++ b/etc/css/scss/settings_lightbox.scss
@@ -2,6 +2,7 @@
    Lightbox Settings | Etc [/etc/css/scss/settings_lightbox.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_nav.scss
+++ b/etc/css/scss/settings_nav.scss
@@ -2,6 +2,7 @@
    Nav Settings | Etc [/etc/css/scss/settings_nav.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_nav_accordion.scss
+++ b/etc/css/scss/settings_nav_accordion.scss
@@ -2,6 +2,7 @@
    Nav Accordion Settings | Etc [/etc/css/scss/settings_nav_accordion.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_nav_drawer.scss
+++ b/etc/css/scss/settings_nav_drawer.scss
@@ -2,6 +2,7 @@
    Nav Drawer Settings | Etc [/etc/css/scss/settings_nav_drawer.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/act/nav_main_act" as *;
 @use "../custom/var/env_var" as *;
 

--- a/etc/css/scss/settings_tables.scss
+++ b/etc/css/scss/settings_tables.scss
@@ -2,6 +2,7 @@
    Tables Settings | Etc [/etc/css/scss/settingsTables.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/settings_text.scss
+++ b/etc/css/scss/settings_text.scss
@@ -2,6 +2,7 @@
    Text Settings | Etc [/etc/css/scss/settings_text.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/var_all_post.scss
+++ b/etc/css/scss/var_all_post.scss
@@ -2,6 +2,7 @@
    CSS Styles Post | Custom [/etc/css/custom/var_all_post.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 @use "sass:color";

--- a/etc/css/scss/var_all_pre.scss
+++ b/etc/css/scss/var_all_pre.scss
@@ -2,6 +2,7 @@
    CSS Styles Pre | Custom [/etc/css/custom/var_all_pre.scss]
    ========================================================================== */
 
+@use "var_all" as *;
 @use "../custom/var/env_var" as *;
 
 /* // Descripcion ----------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- add `@use "var_all" as *;` to the top of the SCSS files under `etc/css/scss/`, respecting header comments
- leave the exception list untouched so shared variables stay centralized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa59ec4c608327b1bd856234ca29eb